### PR TITLE
Propose new protocol: one peripheral per socket

### DIFF
--- a/Documentation/NetworkProtocol.md
+++ b/Documentation/NetworkProtocol.md
@@ -77,7 +77,14 @@ the initial state.
 
 ### Discovery State
 
-The discovery state lasts until the Scratch Extension requests to connect to a peripheral or the discovery times out.
+The discovery state lasts until the Scratch Extension requests to connect to a peripheral or disconnects. The SDM shall
+manage the initiation and/or renewal of scan, enumeration, or other peripheral discovery requests with the host system
+on an ongoing basis until the end of the discovery phase.
+
+If an unreasonable amount of time passes without the Scratch Extension issuing a successful "connect" request or
+disconnecting from the socket, the SDM may end discovery and close the socket connection. This may help save battery
+power on mobile devices, for example.
+
 This state supports the "didDiscoverPeripheral" notification (sent from SDM to Scratch Extension) and the "connect"
 request (sent from Scratch Extension to SDM).
 


### PR DESCRIPTION
This PR proposes a revised network protocol intended to simplify the management of peripheral and socket connection state by tying the network connection to exactly one peripheral connection lifecycle. If we all like this direction then I will continue to work toward implementing this protocol.

I also attempted to remove information specific to a particular device protocol (BLE or Bluetooth Classic) in favor of documenting those details separately.

For review purposes, I recommend clicking the "Display the rich diff" button ;)
![image](https://user-images.githubusercontent.com/7019101/38751059-c47a659a-3f0b-11e8-8d85-b767b97d9fcd.png)
