### PR TITLE
Add sessionWillClose handler to Session

### DIFF
--- a/Sources/scratch-connect/Session.swift
+++ b/Sources/scratch-connect/Session.swift
@@ -15,6 +15,16 @@ class Session {
         self.completionHandlers = [RequestID:JSONRPCCompletionHandler]()
     }
 
+    // Override this to clean up session-specific resources, if any.
+    func sessionWillClose() {
+        if completionHandlers.count > 0 {
+            print("Warning: session closing with \(completionHandlers.count) pending requests")
+            for (_, completionHandler) in completionHandlers {
+                completionHandler(nil, JSONRPCError.InternalError(data: "Session closed"))
+            }
+        }
+    }
+
     // Override this to handle received RPC requests & notifications.
     // Call the completion handler when done with a request:
     // - pass your call's "return value" (or nil) as `result` on success

--- a/Sources/scratch-connect/SessionManager.swift
+++ b/Sources/scratch-connect/SessionManager.swift
@@ -64,6 +64,9 @@ class SessionManager<SessionType: Session>: SessionManagerBase {
     }
 
     func sessionWillClose(_ wss: WebSocketSession) {
+        if let session = sessions[wss] {
+            session.sessionWillClose()
+        }
         wss.delegate = nil
         sessions.removeValue(forKey: wss)
     }


### PR DESCRIPTION
This change provides `Session` objects an opportunity to clean up before the session and associated WebSocket are closed. The default implementation closes all pending completion handlers with an error.