### PR TITLE
Adapt to new WSS sessionWasClosed delegate

### DIFF
--- a/Sources/scratch-connect/Session.swift
+++ b/Sources/scratch-connect/Session.swift
@@ -16,9 +16,9 @@ class Session {
     }
 
     // Override this to clean up session-specific resources, if any.
-    func sessionWillClose() {
+    func sessionWasClosed() {
         if completionHandlers.count > 0 {
-            print("Warning: session closing with \(completionHandlers.count) pending requests")
+            print("Warning: session was closed with \(completionHandlers.count) pending requests")
             for (_, completionHandler) in completionHandlers {
                 completionHandler(nil, JSONRPCError.InternalError(data: "Session closed"))
             }
@@ -157,7 +157,7 @@ class Session {
             throw JSONRPCError.InvalidRequest(data: "response ID value missing or wrong type")
         }
 
-        guard let completionHandler = completionHandlers[id] else {
+        guard let completionHandler = completionHandlers.removeValue(forKey: id) else {
             throw JSONRPCError.InvalidRequest(data: "response ID does not correspond to any open request")
         }
 

--- a/Sources/scratch-connect/SessionManager.swift
+++ b/Sources/scratch-connect/SessionManager.swift
@@ -63,9 +63,9 @@ class SessionManager<SessionType: Session>: SessionManagerBase {
         return session
     }
 
-    func sessionWillClose(_ wss: WebSocketSession) {
+    func sessionWasClosed(_ wss: WebSocketSession) {
         if let session = sessions[wss] {
-            session.sessionWillClose()
+            session.sessionWasClosed()
         }
         wss.delegate = nil
         sessions.removeValue(forKey: wss)


### PR DESCRIPTION
I reworked my `sessionWillClose` Swifter patch (httpswift/swifter#295) to reliably handle both expected and unexpected socket closure. One side effect is that the delegate method is now called `sessionWasClosed` to reflect a change in the timing, so this change updates this repository's code accordingly.

This also fixes a completion handler leak in `Session`'s `didReceiveResponse` method, which I discovered because of the delegate changes.