### PR TITLE
Correctly serialize error response

### DIFF
--- a/Windows/scratch-connect/Session.cs
+++ b/Windows/scratch-connect/Session.cs
@@ -164,7 +164,7 @@ namespace scratch_connect
                 var response = new JObject(
                     new JProperty("jsonrpc", "2.0"),
                     new JProperty("id", responseId),
-                    error == null ? new JProperty("result", result) : new JProperty("error", error)
+                    error == null ? new JProperty("result", result) : new JProperty("error", JObject.FromObject(error))
                 );
 
                 var responseText = JsonConvert.SerializeObject(response);


### PR DESCRIPTION
The `JProperty(string, object)` constructor assumes that the `object` parameter is already a JSON type (like `JObject`, `JValue`, etc.) -- in particular, it doesn't call any conversion function on the object passed in. This was leading to an exception ("Could not determine JSON object type for type") when trying to report errors to the remote caller.

Calling `JObject.FromObject(object)` allows `JsonRpcExceptionConverter` to get in on the action to correctly serialize the error object. This isn't necessary for `result` since `result` is already a `JToken`.