### PR TITLE
Windows BT auto-pairing

### DIFF
--- a/Windows/scratch-connect/BTSession.cs
+++ b/Windows/scratch-connect/BTSession.cs
@@ -163,8 +163,7 @@ namespace scratch_connect
         {
             bluetoothDevice.DeviceInformation.Pairing.Custom.PairingRequested += CustomOnPairingRequested;
             var pairingResult = await bluetoothDevice.DeviceInformation.Pairing.Custom.PairAsync(
-                DevicePairingKinds.ProvidePin | DevicePairingKinds.ConfirmOnly |
-                DevicePairingKinds.ConfirmPinMatch | DevicePairingKinds.DisplayPin);
+                DevicePairingKinds.ProvidePin);
             bluetoothDevice.DeviceInformation.Pairing.Custom.PairingRequested -= CustomOnPairingRequested;
             return pairingResult.Status;
         }
@@ -230,15 +229,7 @@ namespace scratch_connect
         private void CustomOnPairingRequested(DeviceInformationCustomPairing sender,
             DevicePairingRequestedEventArgs args)
         {
-            switch (args.PairingKind)
-            {
-                case DevicePairingKinds.ProvidePin:
-                    args.Accept(_pairingCode);
-                    break;
-                default:
-                    args.Accept();
-                    break;
-            }
+            args.Accept(_pairingCode);
         }
 
         #endregion


### PR DESCRIPTION
All my fancy "I can support all the pairing kinds!" attitude was unfounded, so switching back to only allowing `ProvidePin`. Works great with EV3.