### PR TITLE
Call completion handler after BLE write success

### DIFF
--- a/macOS/Sources/scratch-link/BLESession.swift
+++ b/macOS/Sources/scratch-link/BLESession.swift
@@ -265,6 +265,7 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
             let writeType:CBCharacteristicWriteType =
                     (endpoint.properties.contains(.writeWithoutResponse)) ? .withoutResponse : .withResponse
             peripheral.writeValue(buffer, for: endpoint, type: writeType)
+            completion(buffer.count, nil)
         }
     }
 


### PR DESCRIPTION
The success path in the BLE `write` path was missing a call to its completion handler.

This resolves #29 

Note that we may eventually want to make this more complicated: in the `.withResponse` case, we'll get a callback when all the data is successfully communicated to the peripheral and it could make sense to delay the completion handler call until then. On the other hand, the `.withoutResponse` case receives no callback and will always need to call the completion handler here.

