### PR TITLE
Update Swifter to special scratch-link version

### DIFF
--- a/macOS/Package.resolved
+++ b/macOS/Package.resolved
@@ -5,8 +5,8 @@
         "package": "Swifter",
         "repositoryURL": "https://github.com/cwillisf/swifter.git",
         "state": {
-          "branch": null,
-          "revision": "b3ccf5af78b608f567cbc8c4f96c48c37ad9ac0b",
+          "branch": "scratch-link",
+          "revision": "fa16959ec66b4953e4d954bfe05019a06768270c",
           "version": null
         }
       }

--- a/macOS/Package.swift
+++ b/macOS/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "scratch-link",
 	dependencies: [
-        .package(url: "https://github.com/cwillisf/swifter.git", .revision("b3ccf5af78b608f567cbc8c4f96c48c37ad9ac0b")),
+        .package(url: "https://github.com/cwillisf/swifter.git", .branch("scratch-link")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Resolves #32 

I suspect the underlying problem is threading-related, but so far my attempts at locking & synchronizing various parts of the Scratch Link application haven't resulted in success. This adjustment to the Swifter library, on the other hand, has been 100% reliable for me so far.

The specific change is here:
https://github.com/httpswift/swifter/commit/58e7041eadbaf5fc01a88dc4eab6cffa0cc199f8

CC @ericrosenbaum @evhan55 