### PR TITLE
Ensure session is ready before handling messages

### DIFF
--- a/Windows/scratch-link/SessionManager.cs
+++ b/Windows/scratch-link/SessionManager.cs
@@ -18,22 +18,21 @@ namespace scratch_link
 
         public void ClientDidConnect(IWebSocketConnection webSocket)
         {
-            Session session = null;
+            var session = _sessionCreationDelegate(webSocket);
 
             webSocket.OnOpen = () =>
             {
-                session = _sessionCreationDelegate(webSocket);
                 ++ActiveSessionCount;
                 ((App)(Application.Current)).UpdateIconText();
             };
-            webSocket.OnMessage = async message => await session?.OnMessage(message);
-            webSocket.OnBinary = async message => await session?.OnBinary(message);
+            webSocket.OnMessage = async message => await session.OnMessage(message);
+            webSocket.OnBinary = async message => await session.OnBinary(message);
             webSocket.OnClose = () =>
             {
                 --ActiveSessionCount;
                 ((App)(Application.Current)).UpdateIconText();
-                session?.Dispose();
-                webSocket?.Close();
+                session.Dispose();
+                session = null;
             };
         }
     }


### PR DESCRIPTION
Apparently Fleck doesn't guarantee that `OnMessage` and `OnBinary` won't be called until after `OnOpen` -- rather, it seems to be a race condition. Even [better](https://i.pinimg.com/originals/fa/7c/72/fa7c722b2ab273f3c58f45f5f530457d.jpg), in Scratch Link's case the race seems to be partially determined by whether or not the application is packaged for the store.

This change creates the session object as soon as the WebSocket connects instead of waiting until `OnOpen`, which guarantees that the session object will exist before any methods try to use it.

This may be the cause of #48