### PR TITLE
Add thread safety for WebSocket, derived sessions

### DIFF
--- a/macOS/Sources/scratch-link/BLESession.swift
+++ b/macOS/Sources/scratch-link/BLESession.swift
@@ -48,7 +48,7 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
         }
     }
 
-    required init(withSocket webSocket: WebSocket) {
+    required init(withSocket webSocket: WebSocket) throws {
         self.central = CBCentralManager()
         self.centralDelegateHelper = CBCentralManagerDelegateHelper()
         self.peripheralDelegateHelper = CBPeripheralDelegateHelper()
@@ -56,7 +56,7 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
         self.watchedCharacteristics = []
         self.characteristicDiscoveryCompletion = [:]
         self.onBluetoothReadyTasks = []
-        super.init(withSocket: webSocket)
+        try super.init(withSocket: webSocket)
         self.centralDelegateHelper.delegate = self
         self.central.delegate = self.centralDelegateHelper
         self.peripheralDelegateHelper.delegate = self

--- a/macOS/Sources/scratch-link/BTSession.swift
+++ b/macOS/Sources/scratch-link/BTSession.swift
@@ -14,9 +14,9 @@ class BTSession: Session, IOBluetoothRFCOMMChannelDelegate, IOBluetoothDeviceInq
         case Connected
     }
     
-    required init(withSocket webSocket: WebSocket) {
+    required init(withSocket webSocket: WebSocket) throws {
         inquiry = IOBluetoothDeviceInquiry(delegate: nil)
-        super.init(withSocket: webSocket)
+        try super.init(withSocket: webSocket)
         inquiry.delegate = self
     }
     

--- a/macOS/Sources/scratch-link/SessionManager.swift
+++ b/macOS/Sources/scratch-link/SessionManager.swift
@@ -2,11 +2,11 @@ import Foundation
 import Telegraph
 
 protocol SessionManagerBase {
-    func makeSession(forSocket webSocket: WebSocket) -> Session
+    func makeSession(forSocket webSocket: WebSocket) throws -> Session
 }
 
 class SessionManager<SessionType: Session>: SessionManagerBase {
-    func makeSession(forSocket webSocket: WebSocket) -> Session {
-        return SessionType.init(withSocket: webSocket)
+    func makeSession(forSocket webSocket: WebSocket) throws -> Session {
+        return try SessionType.init(withSocket: webSocket)
     }
 }

--- a/macOS/Sources/scratch-link/main.swift
+++ b/macOS/Sources/scratch-link/main.swift
@@ -101,8 +101,12 @@ class ScratchLink: NSObject, NSApplicationDelegate, ServerWebSocketDelegate {
     func server(_ server: Server, webSocketDidConnect webSocket: WebSocket, handshake: HTTPRequest) {
         print(handshake.uri.path)
         if let sessionManager = sessionManagers[handshake.uri.path] {
-            let session = sessionManager.makeSession(forSocket: webSocket)
-            sessions[ObjectIdentifier(webSocket)] = session
+            if let session = try? sessionManager.makeSession(forSocket: webSocket) {
+                sessions[ObjectIdentifier(webSocket)] = session
+            } else {
+                webSocket.send(text: "Error making session for connection at path: \(handshake.uri.path)")
+                webSocket.close(immediately: false)
+            }
         } else {
             webSocket.send(text: "Unrecognized path: \(handshake.uri.path)")
             webSocket.close(immediately: false)


### PR DESCRIPTION
Resolves #53 (or at least, it seems to...)

My operating theory for #53 is that Telegraph handles WebSocket payloads using a dispatch queue (or something similar) and that occasionally two payloads get handled "simultaneously" on two different worker threads. This is dangerous in at least two ways.

I suspect #53 is caused by two threads attempting to send responses through the WebSocket at the same time and corrupting the data that actually arrives on the browser side of the socket. In most of the cases I can imagine I'd expect something more disastrous than a UTF-8 error, so I assume there's some detail I'm missing, but I strongly suspect the problem is in this neighborhood at least.

It's also possible that two threads might try to modify some session state simultaneously, potentially corrupting session data structures. For example, two threads might try to register change notification for BLE characteristics at simultaneously and potentially corrupt the dictionary that tracks those registrations. I'm not sure that we've seen a problem of this kind, but it seems prudent to protect the derived session state (in `BLESession` and `BTSession`) so that they can think of themselves as single-threaded.

This change introduces a mutex each to protect the WebSocket and the "session" (really, the `didReceiveCall` method and associated completion handlers). Initialization of a mutex can fail, so unfortunately this means that the session initialization can throw and I had to add several layers of exception plumbing. The "real" changes are all in `Session.swift`.