### PR TITLE
Fixing the check for the list of optional services.

### DIFF
--- a/macOS/Sources/scratch-link/BLESession.swift
+++ b/macOS/Sources/scratch-link/BLESession.swift
@@ -112,7 +112,7 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
         }
 
         let newOptionalServices: Set<CBUUID>?
-        if let jsonOptionalServices = params["optionalServices"] as? [String:Any] {
+        if let jsonOptionalServices = params["optionalServices"] as? [String] {
             newOptionalServices = Set<CBUUID>(try jsonOptionalServices.compactMap({
                 guard let uuid = GATTHelpers.GetUUID(forService: $0) else {
                     throw JSONRPCError.InvalidParams(data: "could not resolve UUID for optional service \($0)")


### PR DESCRIPTION
This fixes the BLE check for the list of optional services when specified in the following way, as per the documentation:

```
{
  "jsonrpc": "2.0",     // JSON-RPC version indicator
  "id": 1,              // Message sequence identifier
  "method": "discover", // Command identifier
  "params": {
    "filters": [
      { "name": "My Peripheral" },              // Accept peripheral named exactly "My Peripheral"
      { "services": [ 0x1815, "current_time" ]} // Accept peripheral with both "Automation IO" and "Current Time" services
    ],
    "optionalServices": [
      "00001826-0000-1000-8000-00805f9b34fb"  // Allow the "Fitness Machine" service if present
    ]
  }
}
```

The list of optionalServices was not correctly being parsed before.