### PR TITLE
Added a Organisationally Unique Identifier-prefix (OUI-prefix) to the…

### DIFF
--- a/macOS/Sources/scratch-link/BTSession.swift
+++ b/macOS/Sources/scratch-link/BTSession.swift
@@ -33,7 +33,7 @@ class BTSession: Session, IOBluetoothRFCOMMChannelDelegate, IOBluetoothDeviceInq
             if let major = params["majorDeviceClass"] as? UInt, let minor = params["minorDeviceClass"] as? UInt {
                 if let prefix = params["ouiPrefix"] as? String { self.ouiPrefix = prefix }
                 state = .discovery
-                discover(inMajorDeviceClass: major, inMinorDeviceClass: minor, withPrefix: self.ouiPrefix, completion: completion)
+                discover(inMajorDeviceClass: major, inMinorDeviceClass: minor, completion: completion)
             } else {
                 completion(nil, JSONRPCError.invalidParams(data: "majorDeviceClass and minorDeviceClass required"))
             }


### PR DESCRIPTION
### Resolves

Currently, Scratch Link only filters Bluetooth devices based on a provided major and minor device class. As these device classes are relatively generic, while searching for a specific device, e.g. a LEGO MINDSTORMS EV3, other devices that share the same major and minor device class will appear. 

In this case, the EV3 extension has major class Toy (8) and minor class Robot (1), and it is highly likely that other companies have or will have products that use this exact combination of major and minor device class.

### Proposed Changes

This change adds an optional Organisationally Unique Idenfitier (OUI)-prefix as information for Scratch Link to further filter Bluetooth-devices, so that, for example, only EV3 Programmable Bricks appear when using the EV3 extension.

### Reason for Changes

To avoid users from being shown other devices than those they intend to connect to.

### Test Coverage

No tests have been added.
