### PR TITLE
Windows: Set minimum version to 1709 (build 16299)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ System Requirements:
 | | Minimum
 | --- | ---
 | macOS | 10.10 "Yosemite"
-| Windows&nbsp;10 | "Creators&nbsp;Update" Version&nbsp;1703 (build&nbsp;15063) or newer
+| Windows&nbsp;10 | Version&nbsp;1709 (build&nbsp;16299) "Fall&nbsp;Creators&nbsp;Update" or newer
 
 ## Using Scratch Link with Scratch 3.0
 
@@ -84,13 +84,12 @@ The build is primarily controlled through `make`:
 
 ### Windows
 
-The Windows version of this project is in the `Windows` subdirectory. It uses Visual Studio 2017 and targets Windows
-10.0.15063.0 and higher.
+The Windows version of this project is in the `Windows` subdirectory.
 
 Prerequisites:
 
 * [Visual Studio 2017](https://visualstudio.microsoft.com/vs/) (Community Edition is sufficient)
-* Windows 10.0.15063 SDK (install with Visual Studio)
+* Windows 10.0.16299 SDK (install with Visual Studio)
 * [WiX Toolset](http://wixtoolset.org/releases/) (tested with 3.11.1)
 * [WiX Toolset Visual Studio Extension](
   https://marketplace.visualstudio.com/items?itemName=RobMensching.WixToolsetVisualStudio2017Extension)

--- a/Windows/ScratchLinkAPPX/Package.appxmanifest
+++ b/Windows/ScratchLinkAPPX/Package.appxmanifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp rescap">
   <Identity Name="ScratchFoundation.1711508CFD202" Publisher="CN=2EC43DF1-469A-4119-9AB9-568A0A1FF65F" Version="0.0.0.0" />
   <Properties>
@@ -7,8 +7,7 @@
     <Logo>Images\StoreLogo.png</Logo>
   </Properties>
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.15063.0" MaxVersionTested="10.0.15063.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.16299.0" MaxVersionTested="10.0.17134.407" />
   </Dependencies>
   <Resources>
     <Resource Language="x-generate" />

--- a/Windows/ScratchLinkAPPX/ScratchLinkAPPX.wapproj
+++ b/Windows/ScratchLinkAPPX/ScratchLinkAPPX.wapproj
@@ -19,8 +19,8 @@
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
   <PropertyGroup>
     <ProjectGuid>34a8a49d-cf32-4812-8df1-6a52e664c4ab</ProjectGuid>
-    <TargetPlatformVersion>10.0.15063.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <PackageCertificateKeyFile>ScratchLink_StoreKey.pfx</PackageCertificateKeyFile>
     <EntryPointProjectUniqueName>..\scratch-link\ScratchLink.csproj</EntryPointProjectUniqueName>

--- a/Windows/ScratchLinkSetup/Product.wxs
+++ b/Windows/ScratchLinkSetup/Product.wxs
@@ -15,7 +15,7 @@
         Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion" Name="CurrentBuildNumber"/>
     </Property>
     <Condition Message="This application requires Windows 10 Creators Update or later.">
-      <![CDATA[CURRENTBUILDNUMBER >= 15063]]>
+      <![CDATA[CURRENTBUILDNUMBER >= 16299]]>
     </Condition>
     <UI Id="UserInterface">
       <Property Id="WIXUI_INSTALLDIR" Value="TARGETDIR" />

--- a/Windows/scratch-link.sln
+++ b/Windows/scratch-link.sln
@@ -39,13 +39,12 @@ Global
 		{711F5DBA-7A5D-447A-A9BA-50CB2096E00A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{711F5DBA-7A5D-447A-A9BA-50CB2096E00A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{34A8A49D-CF32-4812-8DF1-6A52E664C4AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{34A8A49D-CF32-4812-8DF1-6A52E664C4AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{34A8A49D-CF32-4812-8DF1-6A52E664C4AB}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{34A8A49D-CF32-4812-8DF1-6A52E664C4AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{34A8A49D-CF32-4812-8DF1-6A52E664C4AB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{34A8A49D-CF32-4812-8DF1-6A52E664C4AB}.Release|Any CPU.Deploy.0 = Release|Any CPU
 		{5AC1AA26-9C7C-4A81-99B7-21222DA0D89E}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{5AC1AA26-9C7C-4A81-99B7-21222DA0D89E}.Release|Any CPU.ActiveCfg = Release|x86
+		{5AC1AA26-9C7C-4A81-99B7-21222DA0D89E}.Release|Any CPU.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Windows/scratch-link/ScratchLink.csproj
+++ b/Windows/scratch-link/ScratchLink.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\MSBuilder.Git.0.3.0\build\MSBuilder.Git.props" Condition="Exists('..\packages\MSBuilder.Git.0.3.0\build\MSBuilder.Git.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -60,7 +60,7 @@
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
     <Reference Include="Windows">
-      <HintPath>..\..\..\..\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.15063.0\Windows.winmd</HintPath>
+      <HintPath>..\..\..\..\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.16299.0\Windows.winmd</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />


### PR DESCRIPTION
### Resolves

Closes #97
Closes LLK/scratch-vm#1681

### Proposed Changes

Increase the Windows 10 version requirement to version 1709 (build 16299).

I also removed the `TargetDeviceFamily` entry for `Windows.Universal`. I believe this is what was causing some views of the Microsoft Store listing to indicate that the app is compatible with an Xbox One -- as long as your Xbox One is running a new enough version of Windows 10. ;p

### Reason for Changes

Windows 10 version 1703 (build 15063) contains a security issue related to BLE support in desktop applications like Scratch Link. In theory we can work around this issue but the workaround is non-trivial. Based on conversation with @thisandagain, including Windows 10 install base statistics, we've decided to increase the version requirement rather than implement the workaround. If we receive enough feedback requesting support for Windows 10 version 1703 we may reconsider in the future.

More details about this issue, including links to more technical information, are available here: https://github.com/LLK/scratch-vm/issues/1681#issuecomment-442627747