### PR TITLE
Do not add OptionalServices to scanForPeripherals filtering

### DIFF
--- a/macOS/Sources/scratch-link/BLESession.swift
+++ b/macOS/Sources/scratch-link/BLESession.swift
@@ -189,7 +189,6 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
 
     func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral,
                         advertisementData: [String: Any], rssi rssiRaw: NSNumber) {
-
         let rssi = RSSI(rawValue: rssiRaw)
         if case .valid(let value) = rssi, value < BLESession.MinimumSignalStrength {
             // signal too weak


### PR DESCRIPTION
### Resolves

Optional services are not considered optional (instead are considered mandatory): 
```
        this._ble = new BLE(this._runtime, this._extensionId, {
            filters: [
                { namePrefix: namePrefix }
            ],
            optionalServices: [
                BLEUUID.service
            ]
        }, this._onConnect);
```

### Proposed Changes

No longer scan for peripherals with specific services, instead scan for all potential peripherals then filter.

### Reason for Changes

Could not connect with this bug for Vernier Go Direct BLE devices.
