### PR TITLE
Windows BLESession 'RequiredServices' check fix

### DIFF
--- a/Windows/scratch-link/BLESession.cs
+++ b/Windows/scratch-link/BLESession.cs
@@ -336,7 +336,7 @@ namespace scratch_link
                 !endpoint.CharacteristicProperties.HasFlag(GattCharacteristicProperties.WriteWithoutResponse);
 
             var result = await endpoint.WriteValueAsync(buffer.AsBuffer(),
-                false ? GattWriteOption.WriteWithResponse : GattWriteOption.WriteWithoutResponse);
+                withResponse ? GattWriteOption.WriteWithResponse : GattWriteOption.WriteWithoutResponse);
 
             switch (result)
             {


### PR DESCRIPTION
### Resolves

- Resolves #108 : "Cannot connect to vernier device on Windows"

### Proposed Changes

- RequiredServices null check