### PR TITLE
Protect WebSocket close in session mutex

### DIFF
--- a/macOS/Sources/scratch-link/Session.swift
+++ b/macOS/Sources/scratch-link/Session.swift
@@ -55,8 +55,6 @@ class Session {
                     completionHandler(nil, JSONRPCError.internalError(data: "Session closed"))
                 }
             }
-        }
-        if self.webSocket.isConnected {
             self.webSocket.close()
         }
     }


### PR DESCRIPTION
### Resolves

Resolves #98

### Proposed Changes

Move the call to close the WebSocket inside the region protected by the session mutex. Also, remove the check to see if the WebSocket is already closed, since the `close()` method does that internally.

### Reason for Changes

In certain conditions (such as those described in #98) the session may attempt to close for two different reasons almost simultaneously. Depending on timing, it may happen that two separate threads reach the `isValid` check in `webSocket.close()` almost simultaneously.

Inside of Perfect there's quite a bit of code after the `isValid` check and before the state changes which cause `isValid` to return false. Unfortunately much of that code is unsafe to run on a WebSocket which has already closed, so if one thread reaches the end of `webSocket.close()` then any other thread currently running `webSocket.close()` is likely to crash.

This change ensures that only one thread will run `webSocket.close()` at a time, and in particular there's no chance that a WebSocket (or other Session) operation will take place in between the socket validity check and the actual socket close operation.

### Testing

This sequence crashes versions of Scratch Link without this change about 75% of the time for me on macOS 10.14 with Safari 12, but I have not seen the crash with other browsers or other versions of macOS.

There are probably other ways to cause this crash but this is the only one I've seen.

1. Use macOS 10.14
2. Open Scratch Link
3. Visit Scratch in Safari 12
4. Add a BLE extension (micro:bit, for example)
5. Refresh the page
6. If Scratch Link doesn't crash, repeat steps 4 & 5 a few times to be sure.

Expected results:
- Scratch Link prior to this change crashes on step 5 at least once
- Scratch Link with this change does not crash on step 5 even after multiple attempts