### PR TITLE
Add getServices to BLE

### DIFF
--- a/Windows/scratch-link/BLESession.cs
+++ b/Windows/scratch-link/BLESession.cs
@@ -169,6 +169,7 @@ namespace scratch_link
                     };
 
                     SendRemoteRequest("getServices", json);
+                    await completion(null, null);
                     break;
                 case "pingMe":
                     await completion("willPing", null);

--- a/Windows/scratch-link/BLESession.cs
+++ b/Windows/scratch-link/BLESession.cs
@@ -157,16 +157,17 @@ namespace scratch_link
                     await completion(null, null);
                     break;
                 case "getServices":
-                    Debug.Print("getServices requested");
                     List<string> allServices = new List<string>();
                     foreach (var s in _services)
                     {
                         allServices.Add(s.Uuid.ToString());
                     }
+
                     var json = new JObject
                     {
                         new JProperty("result", allServices)
                     };
+
                     SendRemoteRequest("getServices", json);
                     break;
                 case "pingMe":

--- a/Windows/scratch-link/BLESession.cs
+++ b/Windows/scratch-link/BLESession.cs
@@ -156,6 +156,19 @@ namespace scratch_link
                     await StopNotifications(parameters);
                     await completion(null, null);
                     break;
+                case "getServices":
+                    Debug.Print("getServices requested");
+                    List<string> allServices = new List<string>();
+                    foreach (var s in _services)
+                    {
+                        allServices.Add(s.Uuid.ToString());
+                    }
+                    var json = new JObject
+                    {
+                        new JProperty("result", allServices)
+                    };
+                    SendRemoteRequest("getServices", json);
+                    break;
                 case "pingMe":
                     await completion("willPing", null);
                     SendRemoteRequest("ping", null, (result, error) =>

--- a/Windows/scratch-link/BLESession.cs
+++ b/Windows/scratch-link/BLESession.cs
@@ -167,9 +167,8 @@ namespace scratch_link
                     {
                         new JProperty("result", allServices)
                     };
-
-                    SendRemoteRequest("getServices", json);
-                    await completion(null, null);
+                    
+                    await completion(json, null);
                     break;
                 case "pingMe":
                     await completion("willPing", null);

--- a/Windows/scratch-link/BLESession.cs
+++ b/Windows/scratch-link/BLESession.cs
@@ -161,14 +161,8 @@ namespace scratch_link
                     foreach (var s in _services)
                     {
                         allServices.Add(s.Uuid.ToString());
-                    }
-
-                    var json = new JObject
-                    {
-                        new JProperty("result", allServices)
-                    };
-                    
-                    await completion(json, null);
+                    }                    
+                    await completion(JToken.FromObject(allServices), null);
                     break;
                 case "pingMe":
                     await completion("willPing", null);

--- a/macOS/Sources/scratch-link/BLESession.swift
+++ b/macOS/Sources/scratch-link/BLESession.swift
@@ -542,7 +542,9 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
         case "getServices":
             var services = [String]()
             connectedPeripheral?.services?.forEach{
-                services.append($0.uuid.uuidString)
+                var s = "0000" + $0.uuid.uuidString
+                s = s + "-0000-1000-8000-00805f9b34fb" // canonicalize UUID
+                services.append(s)
             }
             completion(services, nil)
         case "pingMe":

--- a/macOS/Sources/scratch-link/BLESession.swift
+++ b/macOS/Sources/scratch-link/BLESession.swift
@@ -187,6 +187,14 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
         // swiftlint:enable force_cast
     }
 
+    // Canonicalizing into a full 128-bit UUID string using the canonicalUUID algorithm
+    // see https://webbluetoothcg.github.io/web-bluetooth/#standardized-uuids
+    private func getCanonicalUUIDString(uuid: String) -> String {
+        var canonicalUUID = "0000" + uuid
+        canonicalUUID = canonicalUUID + "-0000-1000-8000-00805f9b34fb"
+        return canonicalUUID
+    }
+
     func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral,
                         advertisementData: [String: Any], rssi rssiRaw: NSNumber) {
         let rssi = RSSI(rawValue: rssiRaw)
@@ -542,10 +550,7 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
         case "getServices":
             var services = [String]()
             connectedPeripheral?.services?.forEach{
-                // canonicalize UUID
-                var s = "0000" + $0.uuid.uuidString
-                s = s + "-0000-1000-8000-00805f9b34fb"
-                services.append(s)
+                services.append(getCanonicalUUIDString(uuid: $0.uuid.uuidString))
             }
             completion(services, nil)
         case "pingMe":

--- a/macOS/Sources/scratch-link/BLESession.swift
+++ b/macOS/Sources/scratch-link/BLESession.swift
@@ -14,6 +14,7 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
     private var optionalServices: Set<CBUUID>?
     private var reportedPeripherals: [CBUUID: CBPeripheral]?
     private var allowedServices: Set<CBUUID>?
+    private var allServices: Set<String>?
 
     private var connectedPeripheral: CBPeripheral?
     private var connectionCompletion: JSONRPCCompletionHandler?
@@ -248,6 +249,12 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
     }
 
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        var all = Set<String>()
+        peripheral.services?.forEach{
+            all.formUnion([$0.uuid.uuidString])
+        }
+        allServices = all
+
         if peripheral != connectedPeripheral {
             print("didDiscoverServices on wrong peripheral")
             return
@@ -539,6 +546,10 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
             startNotifications(withParams: params, completion: completion)
         case "stopNotifications":
             stopNotifications(withParams: params, completion: completion)
+        case "getServices":
+            print("Get services requested")
+            print(allServices)
+            sendRemoteRequest("getServices", withParams: ["result" : Array(allServices ?? [])])
         case "pingMe":
             completion("willPing", nil)
             sendRemoteRequest("ping") { (result: Any?, _: JSONRPCError?) in

--- a/macOS/Sources/scratch-link/BLESession.swift
+++ b/macOS/Sources/scratch-link/BLESession.swift
@@ -14,7 +14,7 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
     private var optionalServices: Set<CBUUID>?
     private var reportedPeripherals: [CBUUID: CBPeripheral]?
     private var allowedServices: Set<CBUUID>?
-    private var allServices: Set<String>?
+    private var allServices: [String]?
 
     private var connectedPeripheral: CBPeripheral?
     private var connectionCompletion: JSONRPCCompletionHandler?
@@ -249,9 +249,9 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
     }
 
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
-        var all = Set<String>()
+        var all = [String]()
         peripheral.services?.forEach{
-            all.formUnion([$0.uuid.uuidString])
+            all.append($0.uuid.uuidString)
         }
         allServices = all
 
@@ -549,7 +549,7 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
         case "getServices":
             print("Get services requested")
             print(allServices)
-            sendRemoteRequest("getServices", withParams: ["result" : Array(allServices ?? [])])
+            sendRemoteRequest("getServices", withParams: ["result" : allServices ?? []])
         case "pingMe":
             completion("willPing", nil)
             sendRemoteRequest("ping") { (result: Any?, _: JSONRPCError?) in

--- a/macOS/Sources/scratch-link/BLESession.swift
+++ b/macOS/Sources/scratch-link/BLESession.swift
@@ -248,7 +248,6 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
     }
 
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
-
         if peripheral != connectedPeripheral {
             print("didDiscoverServices on wrong peripheral")
             return

--- a/macOS/Sources/scratch-link/BLESession.swift
+++ b/macOS/Sources/scratch-link/BLESession.swift
@@ -14,7 +14,6 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
     private var optionalServices: Set<CBUUID>?
     private var reportedPeripherals: [CBUUID: CBPeripheral]?
     private var allowedServices: Set<CBUUID>?
-    private var allServices: [String]?
 
     private var connectedPeripheral: CBPeripheral?
     private var connectionCompletion: JSONRPCCompletionHandler?
@@ -249,11 +248,6 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
     }
 
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
-        var services = [String]()
-        peripheral.services?.forEach{
-            services.append($0.uuid.uuidString)
-        }
-        allServices = services
 
         if peripheral != connectedPeripheral {
             print("didDiscoverServices on wrong peripheral")
@@ -547,7 +541,11 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
         case "stopNotifications":
             stopNotifications(withParams: params, completion: completion)
         case "getServices":
-            sendRemoteRequest("getServices", withParams: ["result" : allServices ?? []])
+            var services = [String]()
+            connectedPeripheral?.services?.forEach{
+                services.append($0.uuid.uuidString)
+            }
+            sendRemoteRequest("getServices", withParams: ["result" : services])
         case "pingMe":
             completion("willPing", nil)
             sendRemoteRequest("ping") { (result: Any?, _: JSONRPCError?) in

--- a/macOS/Sources/scratch-link/BLESession.swift
+++ b/macOS/Sources/scratch-link/BLESession.swift
@@ -544,8 +544,7 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
             connectedPeripheral?.services?.forEach{
                 services.append($0.uuid.uuidString)
             }
-            sendRemoteRequest("getServices", withParams: ["result" : services])
-            completion(nil, nil)
+            completion(services, nil)
         case "pingMe":
             completion("willPing", nil)
             sendRemoteRequest("ping") { (result: Any?, _: JSONRPCError?) in

--- a/macOS/Sources/scratch-link/BLESession.swift
+++ b/macOS/Sources/scratch-link/BLESession.swift
@@ -544,7 +544,7 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
             connectedPeripheral?.services?.forEach{
                 services.append($0.uuid.uuidString)
             }
-            sendRemoteRequest("getServices", withParams: ["result" : services])
+            sendRemoteRequest("getServices", withParams: ["result" : services], completion: completion)
         case "pingMe":
             completion("willPing", nil)
             sendRemoteRequest("ping") { (result: Any?, _: JSONRPCError?) in

--- a/macOS/Sources/scratch-link/BLESession.swift
+++ b/macOS/Sources/scratch-link/BLESession.swift
@@ -544,7 +544,8 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
             connectedPeripheral?.services?.forEach{
                 services.append($0.uuid.uuidString)
             }
-            sendRemoteRequest("getServices", withParams: ["result" : services], completion: completion)
+            sendRemoteRequest("getServices", withParams: ["result" : services])
+            completion(nil, nil)
         case "pingMe":
             completion("willPing", nil)
             sendRemoteRequest("ping") { (result: Any?, _: JSONRPCError?) in

--- a/macOS/Sources/scratch-link/BLESession.swift
+++ b/macOS/Sources/scratch-link/BLESession.swift
@@ -542,8 +542,9 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
         case "getServices":
             var services = [String]()
             connectedPeripheral?.services?.forEach{
+                // canonicalize UUID
                 var s = "0000" + $0.uuid.uuidString
-                s = s + "-0000-1000-8000-00805f9b34fb" // canonicalize UUID
+                s = s + "-0000-1000-8000-00805f9b34fb"
                 services.append(s)
             }
             completion(services, nil)

--- a/macOS/Sources/scratch-link/BLESession.swift
+++ b/macOS/Sources/scratch-link/BLESession.swift
@@ -249,11 +249,11 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
     }
 
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
-        var all = [String]()
+        var services = [String]()
         peripheral.services?.forEach{
-            all.append($0.uuid.uuidString)
+            services.append($0.uuid.uuidString)
         }
-        allServices = all
+        allServices = services
 
         if peripheral != connectedPeripheral {
             print("didDiscoverServices on wrong peripheral")
@@ -547,8 +547,6 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
         case "stopNotifications":
             stopNotifications(withParams: params, completion: completion)
         case "getServices":
-            print("Get services requested")
-            print(allServices)
             sendRemoteRequest("getServices", withParams: ["result" : allServices ?? []])
         case "pingMe":
             completion("willPing", nil)

--- a/playground.html
+++ b/playground.html
@@ -382,6 +382,7 @@
                 if (filterInputs.exactNameInput.value) filter.name = filterInputs.exactNameInput.value;
                 if (filterInputs.namePrefixInput.value) filter.namePrefix = filterInputs.namePrefixInput.value;
                 if (filterInputs.servicesInput.value.trim()) filter.services = filterInputs.servicesInput.value.trim().split(/\s+/);
+                if (filter.services) filter.services = filter.services.map(s => parseInt(s));
                 filters.push(filter);
             }
 

--- a/playground.html
+++ b/playground.html
@@ -295,8 +295,6 @@
                     case 'didReceiveMessage':
                         addLine(`Message received from peripheral: ${stringify(params)}`);
                         break;
-                    case 'getServices':
-                        addLine(`Services received: ${stringify(params)}`);
                     default:
                         return 'nah';
                 }
@@ -384,8 +382,6 @@
                 if (filterInputs.exactNameInput.value) filter.name = filterInputs.exactNameInput.value;
                 if (filterInputs.namePrefixInput.value) filter.namePrefix = filterInputs.namePrefixInput.value;
                 if (filterInputs.servicesInput.value.trim()) filter.services = filterInputs.servicesInput.value.trim().split(/\s+/);
-                // filter.services = [0xf005]; // micro:bit
-                filter.services = ['00001523-1212-efde-1523-785feabcd123']; // WeDo2
                 filters.push(filter);
             }
 

--- a/playground.html
+++ b/playground.html
@@ -427,10 +427,10 @@
                 'getServices'
             ).then(
                 x => {
-                    addLine(`get services resolved to: ${stringify(x)}`);
+                    addLine(`getServices resolved to: ${stringify(x)}`);
                 },
                 e => {
-                    addLine(`get services rejected with: ${stringify(e)}`);
+                    addLine(`getServices rejected with: ${stringify(e)}`);
                 }
             );
         }

--- a/playground.html
+++ b/playground.html
@@ -427,7 +427,7 @@
                 'getServices'
             ).then(
                 x => {
-                    addLine(`get services resolve to: ${stringify(x)}`);
+                    addLine(`get services resolved to: ${stringify(x)}`);
                 },
                 e => {
                     addLine(`get services rejected with: ${stringify(e)}`);

--- a/playground.html
+++ b/playground.html
@@ -384,7 +384,8 @@
                 if (filterInputs.exactNameInput.value) filter.name = filterInputs.exactNameInput.value;
                 if (filterInputs.namePrefixInput.value) filter.namePrefix = filterInputs.namePrefixInput.value;
                 if (filterInputs.servicesInput.value.trim()) filter.services = filterInputs.servicesInput.value.trim().split(/\s+/);
-                filter.services = [0xf005];
+                // filter.services = [0xf005]; // micro:bit
+                filter.services = ['00001523-1212-efde-1523-785feabcd123']; // WeDo2
                 filters.push(filter);
             }
 

--- a/playground.html
+++ b/playground.html
@@ -294,6 +294,8 @@
                     case 'didReceiveMessage':
                         addLine(`Message received from peripheral: ${stringify(params)}`);
                         break;
+                    case 'getServices':
+                        addLine(`Services received: ${stringify(params)}`);
                     default:
                         return 'nah';
                 }
@@ -380,7 +382,8 @@
                 const filter = {};
                 if (filterInputs.exactNameInput.value) filter.name = filterInputs.exactNameInput.value;
                 if (filterInputs.namePrefixInput.value) filter.namePrefix = filterInputs.namePrefixInput.value;
-                if (filterInputs.servicesInput.value.trim()) filter.services = filterInputs.servicesInput.valuetrim().split(/\s+/);
+                if (filterInputs.servicesInput.value.trim()) filter.services = filterInputs.servicesInput.value.trim().split(/\s+/);
+                filter.services = [0xf005];
                 filters.push(filter);
             }
 
@@ -411,9 +414,23 @@
             ).then(
                 x => {
                     addLine(`connect resolved to: ${stringify(x)}`);
+                    getServices();
                 },
                 e => {
                     addLine(`connect rejected with: ${stringify(e)}`);
+                }
+            );
+        }
+
+        function getServices() {
+            Scratch.BLE.sendRemoteRequest (
+                'getServices'
+            ).then(
+                x => {
+                    addLine(`get services resolve to: ${stringify(x)}`);
+                },
+                e => {
+                    addLine(`get services rejected with: ${stringify(e)}`);
                 }
             );
         }

--- a/playground.html
+++ b/playground.html
@@ -24,6 +24,7 @@
         <div>
             <button id="discoverBLE">Discover peripherals</button>
             <button id="connectBLE">Connect to discovered peripheral</button>
+            <button id="getServicesBLE">Get services of connected peripheral</button>
         </div>
         <fieldset>
             <legend>Optional Services</legend>
@@ -414,7 +415,6 @@
             ).then(
                 x => {
                     addLine(`connect resolved to: ${stringify(x)}`);
-                    getServices();
                 },
                 e => {
                     addLine(`connect rejected with: ${stringify(e)}`);
@@ -422,7 +422,7 @@
             );
         }
 
-        function getServices() {
+        function getServicesBLE() {
             Scratch.BLE.sendRemoteRequest (
                 'getServices'
             ).then(
@@ -494,6 +494,7 @@
         attachFunctionToButton('pingBLE', pingBLE);
         attachFunctionToButton('discoverBLE', discoverBLE);
         attachFunctionToButton('connectBLE', connectBLE);
+        attachFunctionToButton('getServicesBLE', getServicesBLE);
 
         attachFunctionToButton('setServiceMicroBit', setServiceMicroBit);
         attachFunctionToButton('readMicroBit', readMicroBit);


### PR DESCRIPTION
### Resolves

#104: BLE 'getServices' possibly not implemented

### Proposed Changes

- Add 'getServices' handler to both macOS and Windows BLESession

### Notes

- This PR used to live here: https://github.com/LLK/scratch-link/pull/115, before the LLK/scratch-link repo changed permissions.  There is some discussion regarding the code and changes there.