### PR TITLE
Don't filter out discovered BT peripherals by `isPresent` (Windows)

### DIFF
--- a/Windows/scratch-link/BTSession.cs
+++ b/Windows/scratch-link/BTSession.cs
@@ -23,6 +23,11 @@ namespace scratch_link
         private const string SignalStrengthPropertyName = "System.Devices.Aep.SignalStrength";
 
         /// <summary>
+        /// Indicates that the device returned is currently paired
+        /// </summary>
+        private const string IsPairedPropertyName = "System.Devices.Aep.IsPaired";
+
+        /// <summary>
         /// Indicates that the device returned is actually available and not discovered from a cache
         /// </summary>
         private const string IsPresentPropertyName = "System.Devices.Aep.IsPresent";
@@ -106,6 +111,7 @@ namespace scratch_link
                 _watcher = DeviceInformation.CreateWatcher(selector, new List<String>
                 {
                     SignalStrengthPropertyName,
+                    IsPairedPropertyName,
                     IsPresentPropertyName,
                     BluetoothAddressPropertyName
                 });
@@ -234,11 +240,15 @@ namespace scratch_link
 
         private void PeripheralDiscovered(DeviceWatcher sender, DeviceInformation deviceInformation)
         {
-            /*if (!deviceInformation.Properties.TryGetValue(IsPresentPropertyName, out var isPresent)
+            if (!deviceInformation.Properties.TryGetValue(IsPresentPropertyName, out var isPresent)
                 || isPresent == null || (bool)isPresent == false)
             {
-                return;
-            }*/
+                if (!deviceInformation.Properties.TryGetValue(IsPairedPropertyName, out var isPaired)
+                    || isPaired == null || (bool)isPaired == false)
+                {
+                    return;
+                }
+            }
             deviceInformation.Properties.TryGetValue(BluetoothAddressPropertyName, out var address);
             deviceInformation.Properties.TryGetValue(SignalStrengthPropertyName, out var rssi);
             var peripheralId = ((string) address)?.Replace(":", "");

--- a/Windows/scratch-link/BTSession.cs
+++ b/Windows/scratch-link/BTSession.cs
@@ -24,7 +24,7 @@ namespace scratch_link
 
         /// <summary>
         /// Indicates that the device returned is actually available and not discovered from a cache
-        /// NOTE: This property is not currently used since it reports 'False' for paired for devices
+        /// NOTE: This property is not currently used since it reports 'False' for paired devices
         /// which are currently advertising and within discoverable range.
         /// </summary>
         private const string IsPresentPropertyName = "System.Devices.Aep.IsPresent";

--- a/Windows/scratch-link/BTSession.cs
+++ b/Windows/scratch-link/BTSession.cs
@@ -24,6 +24,8 @@ namespace scratch_link
 
         /// <summary>
         /// Indicates that the device returned is actually available and not discovered from a cache
+        /// NOTE: This property is not currently used since it reports 'False' for paired for devices
+        /// which are currently advertising and within discoverable range.
         /// </summary>
         private const string IsPresentPropertyName = "System.Devices.Aep.IsPresent";
 
@@ -106,6 +108,7 @@ namespace scratch_link
                 _watcher = DeviceInformation.CreateWatcher(selector, new List<String>
                 {
                     SignalStrengthPropertyName,
+                    IsPresentPropertyName,
                     BluetoothAddressPropertyName
                 });
                 _watcher.Added += PeripheralDiscovered;
@@ -233,6 +236,11 @@ namespace scratch_link
 
         private void PeripheralDiscovered(DeviceWatcher sender, DeviceInformation deviceInformation)
         {
+            // Note that we don't filter out by 'IsPresentPropertyName' here because we need to return devices
+            // which are paired and within discoverable range. However, 'IsPresentPropertyName' is set to False
+            // for paired devices that are discovered automatically from a cache, so we ignore that property
+            // and simply return all discovered devices.
+
             deviceInformation.Properties.TryGetValue(BluetoothAddressPropertyName, out var address);
             deviceInformation.Properties.TryGetValue(SignalStrengthPropertyName, out var rssi);
             var peripheralId = ((string) address)?.Replace(":", "");

--- a/Windows/scratch-link/BTSession.cs
+++ b/Windows/scratch-link/BTSession.cs
@@ -23,11 +23,6 @@ namespace scratch_link
         private const string SignalStrengthPropertyName = "System.Devices.Aep.SignalStrength";
 
         /// <summary>
-        /// Indicates that the device returned is currently paired
-        /// </summary>
-        private const string IsPairedPropertyName = "System.Devices.Aep.IsPaired";
-
-        /// <summary>
         /// Indicates that the device returned is actually available and not discovered from a cache
         /// </summary>
         private const string IsPresentPropertyName = "System.Devices.Aep.IsPresent";
@@ -111,8 +106,6 @@ namespace scratch_link
                 _watcher = DeviceInformation.CreateWatcher(selector, new List<String>
                 {
                     SignalStrengthPropertyName,
-                    IsPairedPropertyName,
-                    IsPresentPropertyName,
                     BluetoothAddressPropertyName
                 });
                 _watcher.Added += PeripheralDiscovered;
@@ -240,25 +233,8 @@ namespace scratch_link
 
         private void PeripheralDiscovered(DeviceWatcher sender, DeviceInformation deviceInformation)
         {
-            if (!deviceInformation.Properties.TryGetValue(IsPresentPropertyName, out var isPresent)
-                || isPresent == null || (bool)isPresent == false)
-            {
-                Debug.Print("isPresent");
-                Debug.Print("isPresent.ToString() returns {0}", isPresent);
-                // return;
-                if (!deviceInformation.Properties.TryGetValue(IsPairedPropertyName, out var isPaired)
-                    || isPaired == null || (bool)isPaired == false)
-                {
-                    return;
-                }
-            }
-            deviceInformation.Properties.TryGetValue(IsPresentPropertyName, out var isPresent);
-            Debug.Print("isPresent = {0}", isPresent);
-            deviceInformation.Properties.TryGetValue(IsPairedPropertyName, out var isPaired);
-            Debug.Print("isPaired = {0}", isPaired);
             deviceInformation.Properties.TryGetValue(BluetoothAddressPropertyName, out var address);
             deviceInformation.Properties.TryGetValue(SignalStrengthPropertyName, out var rssi);
-            Debug.Print("rssi = {0}", rssi);
             var peripheralId = ((string) address)?.Replace(":", "");
 
             var peripheralInfo = new JObject

--- a/Windows/scratch-link/BTSession.cs
+++ b/Windows/scratch-link/BTSession.cs
@@ -1,4 +1,4 @@
-﻿using Fleck;
+using Fleck;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -234,11 +234,11 @@ namespace scratch_link
 
         private void PeripheralDiscovered(DeviceWatcher sender, DeviceInformation deviceInformation)
         {
-            if (!deviceInformation.Properties.TryGetValue(IsPresentPropertyName, out var isPresent)
+            /*if (!deviceInformation.Properties.TryGetValue(IsPresentPropertyName, out var isPresent)
                 || isPresent == null || (bool)isPresent == false)
             {
                 return;
-            }
+            }*/
             deviceInformation.Properties.TryGetValue(BluetoothAddressPropertyName, out var address);
             deviceInformation.Properties.TryGetValue(SignalStrengthPropertyName, out var rssi);
             var peripheralId = ((string) address)?.Replace(":", "");

--- a/Windows/scratch-link/BTSession.cs
+++ b/Windows/scratch-link/BTSession.cs
@@ -243,14 +243,22 @@ namespace scratch_link
             if (!deviceInformation.Properties.TryGetValue(IsPresentPropertyName, out var isPresent)
                 || isPresent == null || (bool)isPresent == false)
             {
+                Debug.Print("isPresent");
+                Debug.Print("isPresent.ToString() returns {0}", isPresent);
+                // return;
                 if (!deviceInformation.Properties.TryGetValue(IsPairedPropertyName, out var isPaired)
                     || isPaired == null || (bool)isPaired == false)
                 {
                     return;
                 }
             }
+            deviceInformation.Properties.TryGetValue(IsPresentPropertyName, out var isPresent);
+            Debug.Print("isPresent = {0}", isPresent);
+            deviceInformation.Properties.TryGetValue(IsPairedPropertyName, out var isPaired);
+            Debug.Print("isPaired = {0}", isPaired);
             deviceInformation.Properties.TryGetValue(BluetoothAddressPropertyName, out var address);
             deviceInformation.Properties.TryGetValue(SignalStrengthPropertyName, out var rssi);
+            Debug.Print("rssi = {0}", rssi);
             var peripheralId = ((string) address)?.Replace(":", "");
 
             var peripheralInfo = new JObject


### PR DESCRIPTION
### Resolves

- Resolves #94: After connecting EV3/SPIKE Prime on windows, can't reconnect without first un-pairing

### Proposed Changes

Remove the check for `isPresent` on the list of discovered devices, because unfortunately that is set to `false` to devices that are _present but previously paired_. Since we want people to be able to connect to devices that have been previously paired, we need to return them in the list of discovered devices, whether they are within range or not.

### Note

This PR leaves the declaration for the `IsPresentPropertyName` variable name on line 28 for possible future use, but it can be removed, too.