### PR TITLE
Auto-pair BT on Windows with '0000'

### DIFF
--- a/Windows/scratch-link/BTSession.cs
+++ b/Windows/scratch-link/BTSession.cs
@@ -37,7 +37,7 @@ namespace scratch_link
         /// <summary>
         /// PIN code for auto-pairing
         /// </summary>
-        private string _pairingCode = "1234";
+        private string _pairingCode = "0000";
 
         private DeviceWatcher _watcher;
         private StreamSocket _connectedSocket;
@@ -134,6 +134,7 @@ namespace scratch_link
             var bluetoothDevice = await BluetoothDevice.FromBluetoothAddressAsync(address);
             if (!bluetoothDevice.DeviceInformation.Pairing.IsPaired)
             {
+                Debug.Print("device not yet paired");
                 if (parameters.TryGetValue("pin", out var pin))
                 {
                     _pairingCode = (string) pin;
@@ -166,8 +167,14 @@ namespace scratch_link
         private async Task<DevicePairingResultStatus> Pair(BluetoothDevice bluetoothDevice)
         {
             bluetoothDevice.DeviceInformation.Pairing.Custom.PairingRequested += CustomOnPairingRequested;
-            var pairingResult = await bluetoothDevice.DeviceInformation.Pairing.Custom.PairAsync(
-                DevicePairingKinds.ProvidePin);
+            var pairingResult = (DevicePairingResult) null;
+            if (_pairingCode == "0000") {
+                pairingResult = await bluetoothDevice.DeviceInformation.Pairing.Custom.PairAsync(
+                    DevicePairingKinds.ConfirmOnly);
+            } else {
+                pairingResult = await bluetoothDevice.DeviceInformation.Pairing.Custom.PairAsync(
+                    DevicePairingKinds.ProvidePin);
+            }
             bluetoothDevice.DeviceInformation.Pairing.Custom.PairingRequested -= CustomOnPairingRequested;
             return pairingResult.Status;
         }

--- a/Windows/scratch-link/BTSession.cs
+++ b/Windows/scratch-link/BTSession.cs
@@ -35,9 +35,14 @@ namespace scratch_link
         private const string BluetoothAddressPropertyName = "System.Devices.Aep.DeviceAddress";
 
         /// <summary>
+        /// PIN code for pairing
+        /// </summary>
+        private string _pairingCode = null;
+
+        /// <summary>
         /// PIN code for auto-pairing
         /// </summary>
-        private string _pairingCode = "0000";
+        private string _autoPairingCode = "0000";
 
         private DeviceWatcher _watcher;
         private StreamSocket _connectedSocket;
@@ -167,7 +172,8 @@ namespace scratch_link
         {
             bluetoothDevice.DeviceInformation.Pairing.Custom.PairingRequested += CustomOnPairingRequested;
             var pairingResult = (DevicePairingResult) null;
-            if (_pairingCode == "0000") {
+            if (_pairingCode == null) {
+                _pairingCode = _autoPairingCode;
                 pairingResult = await bluetoothDevice.DeviceInformation.Pairing.Custom.PairAsync(
                     DevicePairingKinds.ConfirmOnly);
             } else {

--- a/Windows/scratch-link/BTSession.cs
+++ b/Windows/scratch-link/BTSession.cs
@@ -134,7 +134,6 @@ namespace scratch_link
             var bluetoothDevice = await BluetoothDevice.FromBluetoothAddressAsync(address);
             if (!bluetoothDevice.DeviceInformation.Pairing.IsPaired)
             {
-                Debug.Print("device not yet paired");
                 if (parameters.TryGetValue("pin", out var pin))
                 {
                     _pairingCode = (string) pin;


### PR DESCRIPTION
### Resolves

- Resolves #129: SPIKE Prime automatic pairing failing on Windows

### Proposed Changes

Try auto-pairing for BT on Windows (using '0000') if no pin is sent from the VM.

### Reason for Changes

Auto-pairing with '1234' was only working for the EV3.

### Note

This should not land until https://github.com/LLK/scratch-vm/pull/2191 lands first, so that the EV3 extension is sure to be sending its own pairing pin.