### PR TITLE
Windows manufacturer data

### DIFF
--- a/Documentation/BluetoothLE.md
+++ b/Documentation/BluetoothLE.md
@@ -28,6 +28,14 @@ A filter object shall contain one or more of the following properties:
 - "namePrefix": to pass this condition, the peripheral's advertised name must begin with this string.
 - "services": to pass this condition, every service named in this array-valued property must be advertised by the
   peripheral. See the "Service Names" section below for more information on specifying services in this list.
+- "manufacturerData": to pass this condition, the peripheral must advertise manufacturer data for each manufacturer ID
+  key in this key-value object. If the value associated with a particular manufacturer ID is an object with a
+  "dataPrefix" property, a "mask" property, or both, then the data advertised by the peripheral must match as
+  as described by the Web Bluetooth specification for [matching "BluetoothDataFilterInit"](
+  https://webbluetoothcg.github.io/web-bluetooth/#bluetoothdatafilterinit-matches).
+  - If "dataPrefix" is present it must be an array of integers. If absent it is treated as an empty arry.
+  - If "mask" is present it must be an array of integers. If absent it is treated as an array of 255 (0xFF) with
+    length equal to the length of the "dataPrefix" array.
 
 The "optionalServices" array, if present, shall contain service names which the Scratch Extension would like to access
 even if they are not used for filtering. See the "Service Names" section below for more information on specifying
@@ -43,8 +51,19 @@ Example JSON-RPC **request** sent from Scratch Extension to Scratch Link to init
   "method": "discover", // Command identifier
   "params": {
     "filters": [
-      { "name": "My Peripheral" },              // Accept peripheral named exactly "My Peripheral"
-      { "services": [ 0x1815, "current_time" ]} // Accept peripheral with both "Automation IO" and "Current Time" services
+      { "name": "My Peripheral" },               // Accept peripheral named exactly "My Peripheral"
+      { "services": [ 0x1815, "current_time" ]}, // Accept peripheral with both "Automation IO" and "Current Time" services
+      {
+        // Accept peripheral advertising data under manufacturer ID 17
+        // where the low nybble of the first byte of that data is 0x1 (0x01, 0x11, 0x81, etc.)
+        // and the second byte of that data is exactly 0x2A.
+        "manufacturerData": {
+          "17": {
+            "dataPrefix": [0x01, 0x2A]
+            "mask": [0x0F, 0xFF]
+          }
+        }
+      }
     ],
     "optionalServices": [
       "00001826-0000-1000-8000-00805f9b34fb"  // Allow the "Fitness Machine" service if present
@@ -62,7 +81,7 @@ Discovery of a BLE peripheral mimics the
 - The "filters" list must contain at least one filter.
 - Each filter in the "filters" list must be non-trivial. For example, a filter which contains only an empty
   "namePrefix" is not allowed.
-- The "manufacturerData" and "serviceData" filter properties are not supported.
+- The "serviceData" filter property is not supported.
 
 #### Service Names
 

--- a/Documentation/NetworkProtocol.md
+++ b/Documentation/NetworkProtocol.md
@@ -17,6 +17,8 @@ This version number shall follow the Semantic Versioning specification, found he
 
 ### Version History
 
+- Version 1.2:
+  - Add `manufacturerData` filtering for BLE discovery.
 - Version 1.1:
   - Add protocol version number.
   - Bluetooth LE:

--- a/playground.html
+++ b/playground.html
@@ -367,9 +367,57 @@
             servicesDiv.appendChild(servicesInput);
             fieldset.appendChild(servicesDiv);
 
+            const manufacturerDataDiv = document.createElement('div');
+            manufacturerDataDiv.appendChild(document.createTextNode('Discover peripherals with this manufacturer data:'));
+            manufacturerDataDiv.appendChild(document.createElement('br'));
+            const addManufacturerDataFilterButton = document.createElement('button');
+            addManufacturerDataFilterButton.appendChild(document.createTextNode('Add data filter'));
+            const manufacturerDataFilterInputs = [];
+            addManufacturerDataFilterButton.onclick = () => {
+                const manufacturerDataFilter = {};
+                manufacturerDataFilterInputs.push(manufacturerDataFilter);
+                const manufacturerDataFilterFields = document.createElement('fieldset');
+                const manufacturerDataFilterLegend = document.createElement('legend');
+                manufacturerDataFilterLegend.appendChild(document.createTextNode('Manufacturer Data Filter ' + manufacturerDataFilterInputs.length));
+                manufacturerDataFilterFields.appendChild(manufacturerDataFilterLegend);
+
+                const manufacturerIdDiv = document.createElement('div');
+                manufacturerIdDiv.appendChild(document.createTextNode('Manufacturer ID: '));
+                const manufacturerIdInput = document.createElement('input');
+                manufacturerIdInput.type = 'number';
+                manufacturerIdInput.placeholder = '65535';
+                manufacturerIdDiv.appendChild(manufacturerIdInput);
+                manufacturerDataFilterFields.appendChild(manufacturerIdDiv);
+
+                const manufacturerDataPrefixDiv = document.createElement('div');
+                manufacturerDataPrefixDiv.appendChild(document.createTextNode('Data Prefix: '));
+                manufacturerDataPrefixInput = document.createElement('input');
+                manufacturerDataPrefixInput.type = 'text';
+                manufacturerDataPrefixInput.placeholder = '1 2 3';
+                manufacturerDataPrefixDiv.appendChild(manufacturerDataPrefixInput);
+                manufacturerDataFilterFields.appendChild(manufacturerDataPrefixDiv);
+
+                const manufacturerDataMaskDiv = document.createElement('div');
+                manufacturerDataMaskDiv.appendChild(document.createTextNode('Mask: '));
+                manufacturerDataMaskInput = document.createElement('input');
+                manufacturerDataMaskInput.type = 'text';
+                manufacturerDataMaskInput.placeholder = '255 15 255';
+                manufacturerDataMaskDiv.appendChild(manufacturerDataMaskInput);
+                manufacturerDataFilterFields.appendChild(manufacturerDataMaskDiv);
+
+                manufacturerDataFilter.idInput = manufacturerIdInput;
+                manufacturerDataFilter.prefixInput = manufacturerDataPrefixInput;
+                manufacturerDataFilter.maskInput = manufacturerDataMaskInput;
+
+                manufacturerDataDiv.appendChild(manufacturerDataFilterFields);
+            };
+            manufacturerDataDiv.appendChild(addManufacturerDataFilterButton);
+            fieldset.appendChild(manufacturerDataDiv);
+
             filter.exactNameInput = exactNameInput;
             filter.namePrefixInput = namePrefixInput;
             filter.servicesInput = servicesInput;
+            filter.manufacturerDataFilterInputs = manufacturerDataFilterInputs;
 
             const filtersParent = document.getElementById('filtersBLE');
             filtersParent.appendChild(fieldset);
@@ -383,6 +431,21 @@
                 if (filterInputs.namePrefixInput.value) filter.namePrefix = filterInputs.namePrefixInput.value;
                 if (filterInputs.servicesInput.value.trim()) filter.services = filterInputs.servicesInput.value.trim().split(/\s+/);
                 if (filter.services) filter.services = filter.services.map(s => parseInt(s));
+
+                let hasManufacturerDataFilters = false;
+                const manufacturerDataFilters = {};
+                for (manufacturerDataFilterInputs of filterInputs.manufacturerDataFilterInputs) {
+                    if (!manufacturerDataFilterInputs.idInput.value) continue;
+                    const id = manufacturerDataFilterInputs.idInput.value.trim();
+                    const manufacturerDataFilter = {};
+                    manufacturerDataFilters[id] = manufacturerDataFilter;
+                    hasManufacturerDataFilters = true;
+                    if (manufacturerDataFilterInputs.prefixInput.value) manufacturerDataFilter.dataPrefix = manufacturerDataFilterInputs.prefixInput.value.trim().split(/\s+/).map(p => parseInt(p));
+                    if (manufacturerDataFilterInputs.maskInput.value) manufacturerDataFilter.mask = manufacturerDataFilterInputs.maskInput.value.trim().split(/\s+/).map(m => parseInt(m));
+                }
+                if (hasManufacturerDataFilters) {
+                    filter.manufacturerData = manufacturerDataFilters;
+                }
                 filters.push(filter);
             }
 


### PR DESCRIPTION
### Resolves

Toward #112 

### Proposed Changes

- Add support for filtering peripherals by manufacturerData on Windows
- Document manufacturerData filtering

### Reason for Changes

This brings us closer to feature parity with the Web Bluetooth specification, and in particular should allow us to discover BOOST hubs in a way that works well with the latest BOOST firmware.
