### PR TITLE
Add `getVersion` to Scratch Link protocol

### DIFF
--- a/Documentation/Bluetooth.md
+++ b/Documentation/Bluetooth.md
@@ -17,7 +17,7 @@ of these methods.
 
 #### Request: `getVersion`
 
-*Added in network protocol version 1.3*
+*Added in network protocol version 1.2*
 
 No additional version information is provided beyond the base implementation.
 

--- a/Documentation/Bluetooth.md
+++ b/Documentation/Bluetooth.md
@@ -8,7 +8,18 @@ Protocol" document describing the portions of the protocol common to all periphe
 
 ### Initiating Communication with Scratch Link
 
-For Bluetooth (BT) connections, an extension connects to Scratch Link’s WebSocket server at the path "/scratch/bt".
+For Bluetooth (BT) connections, an extension connects to Scratch Link's WebSocket server at the path "/scratch/bt".
+
+### Common Methods
+
+Methods in this section must be supported by all session types. This section documents any protocol-specific qualities
+of these methods.
+
+#### Request: `getVersion`
+
+*Added in network protocol version 1.3*
+
+No additional version information is provided beyond the base implementation.
 
 ### Initial State
 

--- a/Documentation/BluetoothLE.md
+++ b/Documentation/BluetoothLE.md
@@ -20,7 +20,7 @@ of these methods.
 
 #### Request: `getVersion`
 
-*Added in network protocol version 1.3*
+*Added in network protocol version 1.2*
 
 No additional version information is provided beyond the base implementation.
 

--- a/Documentation/BluetoothLE.md
+++ b/Documentation/BluetoothLE.md
@@ -11,7 +11,18 @@ can be found here: <https://webbluetoothcg.github.io/web-bluetooth/>
 
 ### Initiating Communication with Scratch Link
 
-For BLE connections, an extension connects to Scratch Link’s WebSocket server at the path "/scratch/ble".
+For BLE connections, an extension connects to Scratch Link's WebSocket server at the path "/scratch/ble".
+
+### Common Methods
+
+Methods in this section must be supported by all session types. This section documents any protocol-specific qualities
+of these methods.
+
+#### Request: `getVersion`
+
+*Added in network protocol version 1.3*
+
+No additional version information is provided beyond the base implementation.
 
 ### Initial State
 

--- a/Documentation/NetworkProtocol.md
+++ b/Documentation/NetworkProtocol.md
@@ -17,6 +17,8 @@ This version number shall follow the Semantic Versioning specification, found he
 
 ### Version History
 
+- Version 1.3:
+  - Add common `getVersion` method.
 - Version 1.2:
   - Add `manufacturerData` filtering for BLE discovery.
 - Version 1.1:
@@ -42,8 +44,44 @@ The JSON-RPC 2.0 specification may be found here: <http://www.jsonrpc.org/specif
 
 Communication with Scratch Link is performed over WebSockets. When initiating a WebSocket connection between the Scratch
 Extension and Scratch Link, the choice of path determines which Transport Protocol will be used. For example, when
-initiating a BLE connection the extension connects to Scratch Link’s WebSocket server at path `/scratch/ble`, and for
+initiating a BLE connection the extension connects to Scratch Link's WebSocket server at path `/scratch/ble`, and for
 Bluetooth Classic (BT) connections the extension connects to the path `/scratch/bt`.
+
+### Common Methods
+
+Methods in this section must be supported by all session types. In general, these methods are stateless unless
+otherwise specified.
+
+#### Request: `getVersion`
+
+*Added in network protocol version 1.3*
+
+This is a JSON-RPC **request** sent from Scratch Extension to Scratch Link to retrieve version information about
+Scratch Link itself. No parameters are necessary.
+
+```json5
+{
+  "jsonrpc": "2.0",      // JSON-RPC version indicator
+  "id": 1,               // Message sequence identifier
+  "method": "getVersion" // Command identifier
+}
+```
+
+JSON-RPC **response** sent from Scratch Link to Scratch Extension .
+
+```json5
+{
+  "jsonrpc": "2.0",   // JSON-RPC version indicator
+  "id": 1,            // Message sequence identifier
+  "result": {
+    "protocol": "1.3" // Version number for the overall network protocol
+  }
+}
+```
+
+The version number in the `protocol` property corresponds to the network protocol version defined in this document.
+Other properties may be present and may contain more version information about the particular session; see
+protocol-specific documentation for details.
 
 ### Stateful Connections
 

--- a/Documentation/NetworkProtocol.md
+++ b/Documentation/NetworkProtocol.md
@@ -17,10 +17,9 @@ This version number shall follow the Semantic Versioning specification, found he
 
 ### Version History
 
-- Version 1.3:
-  - Add common `getVersion` method.
 - Version 1.2:
   - Add `manufacturerData` filtering for BLE discovery.
+  - Add common `getVersion` method.
 - Version 1.1:
   - Add protocol version number.
   - Bluetooth LE:
@@ -54,7 +53,7 @@ otherwise specified.
 
 #### Request: `getVersion`
 
-*Added in network protocol version 1.3*
+*Added in network protocol version 1.2*
 
 This is a JSON-RPC **request** sent from Scratch Extension to Scratch Link to retrieve version information about
 Scratch Link itself. No parameters are necessary.
@@ -74,7 +73,7 @@ JSON-RPC **response** sent from Scratch Link to Scratch Extension .
   "jsonrpc": "2.0",   // JSON-RPC version indicator
   "id": 1,            // Message sequence identifier
   "result": {
-    "protocol": "1.3" // Version number for the overall network protocol
+    "protocol": "1.2" // Version number for the overall network protocol
   }
 }
 ```

--- a/Windows/scratch-link/BLESession.cs
+++ b/Windows/scratch-link/BLESession.cs
@@ -168,16 +168,10 @@ namespace scratch_link
                     }
                     await completion(JToken.FromObject(allServices), null);
                     break;
-                case "pingMe":
-                    await completion("willPing", null);
-                    SendRemoteRequest("ping", null, (result, error) =>
-                    {
-                        Debug.Print($"Got result from ping: {result}");
-                        return Task.CompletedTask;
-                    });
-                    break;
                 default:
-                    throw JsonRpcException.MethodNotFound(method);
+                    // unrecognized method: pass to base class
+                    await base.DidReceiveCall(method, parameters, completion);
+                    break;
             }
         }
 

--- a/Windows/scratch-link/BTSession.cs
+++ b/Windows/scratch-link/BTSession.cs
@@ -91,7 +91,9 @@ namespace scratch_link
                     await completion(await SendMessage(parameters), null);
                     break;
                 default:
-                    throw JsonRpcException.MethodNotFound(method);
+                    // unrecognized method: pass to base class
+                    await base.DidReceiveCall(method, parameters, completion);
+                    break;
             }
         }
 

--- a/Windows/scratch-link/Session.cs
+++ b/Windows/scratch-link/Session.cs
@@ -16,7 +16,7 @@ namespace scratch_link
     internal abstract class Session : IDisposable
     {
         // Keep this in sync with the version number in `NetworkProtocol.md`
-        private const string NetworkProtocolVersion = "1.3";
+        private const string NetworkProtocolVersion = "1.2";
 
         private static readonly Encoding Encoding = Encoding.UTF8;
 

--- a/Windows/scratch-link/Session.cs
+++ b/Windows/scratch-link/Session.cs
@@ -1,4 +1,4 @@
-﻿using Fleck;
+using Fleck;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -15,6 +15,9 @@ namespace scratch_link
 
     internal abstract class Session : IDisposable
     {
+        // Keep this in sync with the version number in `NetworkProtocol.md`
+        private const string NetworkProtocolVersion = "1.3";
+
         private static readonly Encoding Encoding = Encoding.UTF8;
 
         private readonly IWebSocketConnection _webSocket;
@@ -66,13 +69,46 @@ namespace scratch_link
         }
 
         // Override this to handle received RPC requests & notifications.
+        // Call this method with `await super.DidReceiveCall(...)` to implement default calls like `getVersion`.
         // Call the completion handler when done with a request:
         // - pass your call's "return value" (or null) as `result` on success
         // - pass an instance of `JsonRpcException` for `error` on failure
         // You may also throw a `JsonRpcException` (or any other `Exception`) to signal failure.
         // Exceptions are caught even when thrown in an `async` method after `await`:
         // http://www.interact-sw.co.uk/iangblog/2010/11/01/csharp5-async-exceptions
-        protected abstract Task DidReceiveCall(string method, JObject parameters, CompletionHandler completion);
+        protected virtual async Task DidReceiveCall(string method, JObject parameters, CompletionHandler completion)
+        {
+            switch (method)
+            {
+                case "pingMe":
+                    await completion("willPing", null);
+                    SendRemoteRequest("ping", null, (result, error) =>
+                    {
+                        Debug.Print($"Got result from ping: {result}");
+                        return Task.CompletedTask;
+                    });
+                    break;
+                case "getVersion":
+                    await completion(GetVersion(), null);
+                    break;
+                default:
+                    // unrecognized method
+                    throw JsonRpcException.MethodNotFound(method);
+            }
+        }
+
+        // Create a `JObject` containing version information. All version values must be strings.
+        // This base version puts the network protocol version in a property called `protocol`.
+        // Subclasses may choose to override this method to add more info; the recommended pattern is:
+        //   var versionInfo = base.GetVersion();
+        //   versionInfo.Add("mySpecialVersion", someValue);
+        //   return versionInfo;
+        protected virtual JObject GetVersion()
+        {
+            return new JObject(
+                new JProperty("protocol", NetworkProtocolVersion)
+            );
+        }
 
         // Omit (or pass null for) the completion handler to send a Notification.
         // Completion handlers may be async. If your completion handler is not async, return `Task.CompletedTask`.

--- a/macOS/Sources/scratch-link/BLESession.swift
+++ b/macOS/Sources/scratch-link/BLESession.swift
@@ -553,13 +553,9 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
                 services.append(getCanonicalUUIDString(uuid: $0.uuid.uuidString))
             }
             completion(services, nil)
-        case "pingMe":
-            completion("willPing", nil)
-            sendRemoteRequest("ping") { (result: Any?, _: JSONRPCError?) in
-                print("Got result from ping:", String(describing: result))
-            }
         default:
-            throw JSONRPCError.methodNotFound(data: method)
+            // unrecognized method: pass to base class
+            try super.didReceiveCall(method, withParams: params, completion: completion)
         }
     }
 }

--- a/macOS/Sources/scratch-link/Session.swift
+++ b/macOS/Sources/scratch-link/Session.swift
@@ -4,6 +4,9 @@ import PerfectWebSockets
 
 // TODO: implement remaining JSON-RPC 2.0 features like batching
 class Session {
+    // Keep this in sync with the version number in `NetworkProtocol.md`
+    private let NetworkProtocolVersion: String = "1.3"
+
     typealias RequestID = Int
     typealias JSONRPCCompletionHandler = (_ result: Any?, _ error: JSONRPCError?) -> Void
 
@@ -82,13 +85,37 @@ class Session {
     }
 
     // Override this to handle received RPC requests & notifications.
+    // Call this method with `await super.DidReceiveCall(...)` to implement default calls like `getVersion`.
     // Call the completion handler when done with a request:
     // - pass your call's "return value" (or nil) as `result` on success
     // - pass an instance of `JSONRPCError` for `error` on failure
     // You may also throw a `JSONRPCError` (or any other `Error`) iff it is encountered synchronously.
     func didReceiveCall(_ method: String, withParams params: [String: Any],
                         completion: @escaping JSONRPCCompletionHandler) throws {
-        preconditionFailure("Must override didReceiveCall")
+        switch method {
+        case "pingMe":
+            completion("willPing", nil)
+            sendRemoteRequest("ping") { (result: Any?, _: JSONRPCError?) in
+                print("Got result from ping:", String(describing: result))
+            }
+        case "getVersion":
+            completion(getVersion(), nil)
+        default:
+            throw JSONRPCError.methodNotFound(data: method)
+        }
+    }
+
+    // Create an associative array containing version information. All version values must be strings.
+    // This base version puts the network protocol version in a property called `protocol`.
+    // Subclasses may choose to override this method to add more info; the recommended pattern is:
+    //   var versionInfo = super.getVersion()
+    //   versionInfo["mySpecialVersion"] = someValue
+    //   return versionInfo
+    func getVersion() -> [String: String] {
+        let versionInfo: [String: String] = [
+            "protocol": NetworkProtocolVersion
+        ]
+        return versionInfo
     }
 
     // Pass nil for the completion handler to send a Notification

--- a/macOS/Sources/scratch-link/Session.swift
+++ b/macOS/Sources/scratch-link/Session.swift
@@ -5,7 +5,7 @@ import PerfectWebSockets
 // TODO: implement remaining JSON-RPC 2.0 features like batching
 class Session {
     // Keep this in sync with the version number in `NetworkProtocol.md`
-    private let NetworkProtocolVersion: String = "1.3"
+    private let NetworkProtocolVersion: String = "1.2"
 
     typealias RequestID = Int
     typealias JSONRPCCompletionHandler = (_ result: Any?, _ error: JSONRPCError?) -> Void

--- a/playground.html
+++ b/playground.html
@@ -19,6 +19,7 @@
         <legend>BLE</legend>
         <div>
             <button id="initBLE">Connect to app</button>
+            <button id="getVersionBLE">Get Version</button>
             <button id="pingBLE">Request ping</button>
         </div>
         <div>
@@ -53,6 +54,7 @@
         <legend>BT / EV3</legend>
         <div>
             <button id="initBT">Connect to app (BT)</button>
+            <button id="getVersionBT">Get Version</button>
             <button id="discoverBT">Find BT devices</button>
             <button id="closeBT">Goodbye</button>
         </div>
@@ -314,6 +316,17 @@
             }
         }
 
+        function getVersion(session) {
+            session.sendRemoteRequest('getVersion').then(
+                x => {
+                    addLine(`Version request resolved with: ${stringify(x)}`);
+                },
+                e => {
+                    addLine(`Version request rejected with: ${stringify(e)}`);
+                }
+            );
+        }
+
         function initBLE() {
             addLine('Connecting...');
             self.Scratch.BLE = new ScratchBLE();
@@ -552,6 +565,7 @@
         }
 
         attachFunctionToButton('initBLE', initBLE);
+        attachFunctionToButton('getVersionBLE', () => getVersion(self.Scratch.BLE));
         attachFunctionToButton('pingBLE', pingBLE);
         attachFunctionToButton('discoverBLE', discoverBLE);
         attachFunctionToButton('connectBLE', connectBLE);
@@ -644,6 +658,7 @@
         };
 
         attachFunctionToButton('initBT', initBT);
+        attachFunctionToButton('getVersionBT', () => getVersion(self.Scratch.BT));
         attachFunctionToButton('discoverBT', discoverBT);
         attachFunctionToButton('connectBT', connectBT);
         attachFunctionToButton('send', sendMessage);


### PR DESCRIPTION
### Proposed Changes

Adds a `getVersion` command to all session types. This command retrieves version information -- in particular, the protocol version implemented by Scratch Link.

Because of the new protocol feature I've bumped the protocol version to 1.3; if `getVersion` fails then the caller may assume that it's connected to a copy of Scratch Link implementing protocol version 1.2 or below.

I want to stress that this is the protocol version and not the application version of Scratch Link. Presumably other applications may implement this protocol; those applications should report the version of the protocol they implement rather than the application version.

This new feature is also documented in `NetworkProtocol.md`. I left it fairly open-ended so that we can (for example) add the application version later if we discover that it would help.

### Reason for Changes

This will allow extensions to adjust their communication with Scratch Link to use or avoid new or old features if necessary. Hopefully there won't be much occasion for this but it's better to have `getVersion` and not need it than the other way around.

### Note to reviewers

I recommend hiding whitespace changes for `BTSession.swift` since otherwise you'll see that almost every line in `BTSession.swift`'s `didReceiveCall` method has changed indentation.