### PR TITLE
Windows: Remove WPF & convert to Windows Forms only

### DIFF
--- a/Windows/scratch-link/Program.cs
+++ b/Windows/scratch-link/Program.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Windows.Forms;
+
+namespace scratch_link
+{
+    static class Program
+    {
+        /// <summary>
+        /// The main entry point for the application.
+        /// </summary>
+        [STAThread]
+        static void Main()
+        {
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+            var appContext = new App();
+            Application.Run(appContext);
+        }
+    }
+}

--- a/Windows/scratch-link/Properties/AssemblyInfo.cs
+++ b/Windows/scratch-link/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
-﻿using System.Reflection;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Windows;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -10,7 +10,7 @@ using System.Windows;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Scratch Link")]
-[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -19,21 +19,5 @@ using System.Windows;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
-//In order to begin building localizable applications, set
-//<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
-//inside a <PropertyGroup>.  For example, if you are using US english
-//in your source files, set the <UICulture> to en-US.  Then uncomment
-//the NeutralResourceLanguage attribute below.  Update the "en-US" in
-//the line below to match the UICulture setting in the project file.
-
-//[assembly: NeutralResourcesLanguage("en-US", UltimateResourceFallbackLocation.Satellite)]
-
-
-[assembly: ThemeInfo(
-    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
-                                     //(used if a resource is not found in the page,
-                                     // or application resource dictionaries)
-    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
-                                              //(used if a resource is not found in the page,
-                                              // app, or any theme specific resource dictionaries)
-)]
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("711f5dba-7a5d-447a-a9ba-50cb2096e00a")]

--- a/Windows/scratch-link/Properties/Resources.Designer.cs
+++ b/Windows/scratch-link/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace scratch_link.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/Windows/scratch-link/Properties/Settings.settings
+++ b/Windows/scratch-link/Properties/Settings.settings
@@ -1,5 +1,5 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="uri:settings" CurrentProfile="(Default)">
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)">
   <Profiles>
     <Profile Name="(Default)" />
   </Profiles>

--- a/Windows/scratch-link/ScratchLink.csproj
+++ b/Windows/scratch-link/ScratchLink.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\MSBuilder.Git.0.3.0\build\MSBuilder.Git.props" Condition="Exists('..\packages\MSBuilder.Git.0.3.0\build\MSBuilder.Git.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -11,9 +11,9 @@
     <AssemblyName>ScratchLink</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -41,7 +41,9 @@
     <Reference Include="Fleck, Version=1.0.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Fleck.1.0.3\lib\net45\Fleck.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL" />
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
@@ -56,21 +58,12 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xaml">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
     <Reference Include="Windows">
       <HintPath>C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.16299.0\Windows.winmd</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
-    <ApplicationDefinition Include="App.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </ApplicationDefinition>
     <Compile Include="AssemblyExtensions.cs" />
     <Compile Include="BLESession.cs" />
     <Compile Include="EncodingHelpers.cs" />
@@ -79,15 +72,8 @@
     <Compile Include="JSONRPCException.cs" />
     <Compile Include="Session.cs" />
     <Compile Include="SessionManager.cs" />
-    <Compile Include="App.xaml.cs">
-      <DependentUpon>App.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
+    <Compile Include="App.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -98,6 +84,7 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
+    <Compile Include="Program.cs" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/Windows/scratch-link/SessionManager.cs
+++ b/Windows/scratch-link/SessionManager.cs
@@ -1,12 +1,12 @@
-﻿using Fleck;
+using Fleck;
 using System;
-using System.Windows;
 
 namespace scratch_link
 {
     internal class SessionManager
     {
         public int ActiveSessionCount { get; private set; }
+        public event EventHandler ActiveSessionCountChanged;
 
         private readonly Func<IWebSocketConnection, Session> _sessionCreationDelegate;
 
@@ -23,14 +23,14 @@ namespace scratch_link
             webSocket.OnOpen = () =>
             {
                 ++ActiveSessionCount;
-                ((App)(Application.Current)).UpdateIconText();
+                ActiveSessionCountChanged(this, null);
             };
             webSocket.OnMessage = async message => await session.OnMessage(message);
             webSocket.OnBinary = async message => await session.OnBinary(message);
             webSocket.OnClose = () =>
             {
                 --ActiveSessionCount;
-                ((App)(Application.Current)).UpdateIconText();
+                ActiveSessionCountChanged(this, null);
                 session.Dispose();
                 session = null;
             };

--- a/Windows/scratch-link/packages.config
+++ b/Windows/scratch-link/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="Fleck" version="1.0.3" targetFramework="net462" />
   <package id="MSBuilder.Git" version="0.3.0" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
### Resolves

This should make it easier to work on the UI of Scratch Link.

### Background Info

Windows Forms is the "old" way to do UI in Windows, and WPF is the "new" way (as of 2006 or so). That said, Windows Forms is still popular with developers and is well supported by Microsoft. Some Forms features, such as `NotifyIcon`, are still missing from WPF and might never be ported over.

### Proposed Changes

This PR removes all references to WPF and alters any "WPF style" operations to use the Windows Forms equivalent instead.

Supporting changes:
- Updates to the notification icon text are now instigated through an event handler instead of calling `Application.Current`, which is a WPF-specific feature. I think the event handler approach is better anyway.
- I discovered that the JSON library we use wasn't properly registered in `packages.config` which could cause problems building from scratch. I suspect this was caused by forgetting to check in `packages.config` in the early days of the project. At any rate, it's fixed now. I kept the same version we were already using.

There are also a lot of changes to boilerplate code here; sorry about that. I made this change by creating a new, empty Windows Forms project in Visual Studio then adding all the necessary parts back in. That approach was much easier than trying to mutate it in place, but it means there's a lot of noise around the signal when looking at the diffs.

### Reason for Changes

Since the Windows version of Scratch Link works by placing a `NotifyIcon` in the Windows notification area, and that feature doesn't exist in WPF, we have no choice but to use Windows Forms. When I first set up Scratch Link I didn't know this so initially I set it up as a WPF application. Later, I used Forms features when it came time to add the notification icon. We don't have any other UI in Scratch Link, so it was a bit silly to have the WPF libraries hooked up. I don't think it was causing practical problems, but it could cause confusion for someone trying to add more UI or read through the project structure.

The reason I'm making this change now is that I'm looking at enhancing the "Address in Use" error dialog. Doing so will require making a new dialog instead of using the builtin default, so I need to choose either WPF or WinForms. I started down the WPF road and then noticed that we were using the WinForms version of the default `MessageBox`, so I accidentally this PR.
