### PR TITLE
Allow extension to force to BLE write without response as well as with response

### DIFF
--- a/Windows/scratch-link/BLESession.cs
+++ b/Windows/scratch-link/BLESession.cs
@@ -338,7 +338,7 @@ namespace scratch_link
         {
             var buffer = EncodingHelpers.DecodeBuffer(parameters);
             var endpoint = await GetEndpoint("write request", parameters, GattHelpers.BlockListStatus.ExcludeWrites);
-            var withResponse = (parameters["withResponse"]?.ToObject<bool>() ?? false) ||
+            var withResponse = parameters["withResponse"]?.ToObject<bool>() ??
                 !endpoint.CharacteristicProperties.HasFlag(GattCharacteristicProperties.WriteWithoutResponse);
 
             var result = await endpoint.WriteValueWithResultAsync(buffer.AsBuffer(),


### PR DESCRIPTION
### Resolves

Resolves #150 

### Proposed Changes

* On BLE write, respect that the ```withResponse``` parameter is ```false``` regardless of "write without response" capability flag on the characteristic

### Reason for Changes

In some cases, write with response causes a critical performance issue.
Here is a comparison table of average elapsed time on my development PC with a bluetooth adapter.

| BLE peripheral | write with response | write without response |
|---|:---:|:---:|
| micro:bit | 161.9 ms | 1.9 ms |
| LEGO BOOST | 123.4 ms | 3.6 ms |

So, I am proposing this PR so that an extension forces to write without response to resolve the critical performance issue. As @cwillisf mentioned, any outcome should be the extension's response.

Please note that specifying with response has been already supported in #71.

This PR should be merged with https://github.com/LLK/scratch-vm/pull/2298.