### PR TITLE
Cache all characteristics in all services once a peripheral is connected

### DIFF
--- a/Windows/scratch-link/BLESession.cs
+++ b/Windows/scratch-link/BLESession.cs
@@ -301,6 +301,14 @@ namespace scratch_link
             _peripheral.ConnectionStatusChanged += OnPeripheralStatusChanged;
             _services = servicesResult.Services;
 
+            // cache all characteristics in all services
+            foreach (var service in _services) {
+                var characteristicsResult = await service.GetCharacteristicsAsync(BluetoothCacheMode.Uncached);
+                foreach (var characteristic in characteristicsResult.Characteristics) {
+                    _cachedCharacteristics.Add(characteristic.Uuid, characteristic);
+                }
+            }
+
             // collect optional services plus all services from all filters
             // Note: this modifies _optionalServices for convenience since we know it'll go away soon.
             _allowedServices = _optionalServices ?? new HashSet<Guid>();

--- a/Windows/scratch-link/BLESession.cs
+++ b/Windows/scratch-link/BLESession.cs
@@ -304,6 +304,10 @@ namespace scratch_link
             // cache all characteristics in all services
             foreach (var service in _services) {
                 var characteristicsResult = await service.GetCharacteristicsAsync(BluetoothCacheMode.Uncached);
+                if (characteristicsResult.Status != GattCommunicationStatus.Success) {
+                    continue;
+                }
+
                 foreach (var characteristic in characteristicsResult.Characteristics) {
                     _cachedCharacteristics.Add(characteristic.Uuid, characteristic);
                 }


### PR DESCRIPTION
### Resolves

Resolves #151 

### Proposed Changes

* Cache all characteristics in all services once a peripheral is connected

### Reason for Changes

I encounter an annoying issue that read/write for each characteristic has a delay (approximately 1 second) on Windows.
This delay is caused by ```service.GetCharacteristicsAsync(BluetoothCacheMode.Uncached)``` in ```BLESession#GetEndpoint()``` which takes 1 second on my development PC with a bluetooth adapter.

Avoid this, I would like to propose this PR to cache all characteristics once a peripheral is connected.

Fortunately this does not significantly increase duration on connecting phase to the peripheral.

|   | Additional duration |
|---|:---:|
| micro:bit | 1.9 s |
| LEGO BOOST | 1.2 s |