### PR TITLE
Fix missing the warning dialog of "port 20110 is already in use" on Windows

### DIFF
--- a/Windows/scratch-link/App.cs
+++ b/Windows/scratch-link/App.cs
@@ -60,7 +60,7 @@ namespace scratch_link
             }
 
             var certificate = new X509Certificate2(scratch_link.Properties.Resources.WssCertificate, "Scratch");
-            _server = new WebSocketServer($"wss://0.0.0.0:{SDMPort}")
+            _server = new WebSocketServer($"wss://0.0.0.0:{SDMPort}", false)
             {
                 RestartAfterListenError = true,
                 Certificate = certificate


### PR DESCRIPTION
### Resolves

Fixes missing the warning dialog of "port 20110 is already in use"

### Proposed Changes

* Disable dual stack in Fleck

### Reason for Changes

Our testing team founds an issue that there is no warning dialog of "port 20110 is already in use".

According to [the latest implementation](https://github.com/statianzo/Fleck/blob/master/src/Fleck/WebSocketServer.cs#L30-L37), Fleck v1.1.0 supports dual stack by reusing the port with ```SocketOptionName.ReuseAddress```.
When the port 20110 is already in use, this causes ```System.Net.Sockets.SocketException``` instead of ```SocketError.AddressAlreadyInUse```.

Avoid this unexpected behavior, dual stack should be disabled.



