### PR TITLE
BLE: allow client to override write with/without response

### DIFF
--- a/Documentation/BluetoothLE.md
+++ b/Documentation/BluetoothLE.md
@@ -274,11 +274,13 @@ controls which of these modes shall be used for a particular write.
   the write was received without error, and Scratch Link's response to the client shall report any error reported by the
   BLE peripheral. If the peripheral reports an error, that error shall be forwarded to the client as an error response
   to the "write" request.
-- If false or absent, Scratch Link shall write without response. That is, Scratch Link shall make a [best-effort
+- If false, Scratch Link shall write without response. That is, Scratch Link shall make a [best-effort
   delivery](https://en.wikipedia.org/wiki/Best-effort_delivery) attempt then report success. There is no way for the
   peripheral to report an error in this mode.
-- If the peripheral or characteristic does not support writing with response, Scratch Link may choose to write without
-  response even when the "withResponse" flag is true.
+- If absent, Scratch Link shall check if the characteristic appears to support writing without response. If so,
+  Scratch Link shall write without response. Otherwise, Scratch shall write with response.
+
+Generally, writing without response is significantly faster.
 
 On success, Scratch Link's **response** shall contain the number of bytes written, which may differ from the number of
 characters in the string value of the initiating request's "message" property:

--- a/Documentation/NetworkProtocol.md
+++ b/Documentation/NetworkProtocol.md
@@ -17,6 +17,10 @@ This version number shall follow the Semantic Versioning specification, found he
 
 ### Version History
 
+- Version 1.3:
+  - Bluetooth LE:
+    - Alter Scratch Link's handling of the `withResponse` flag on a `write` request. The flag now overrides Scratch
+      Link's detection of GATT characteristic flags.
 - Version 1.2:
   - Add `manufacturerData` filtering for BLE discovery.
   - Add common `getVersion` method.

--- a/Windows/scratch-link/BLESession.cs
+++ b/Windows/scratch-link/BLESession.cs
@@ -338,7 +338,7 @@ namespace scratch_link
         {
             var buffer = EncodingHelpers.DecodeBuffer(parameters);
             var endpoint = await GetEndpoint("write request", parameters, GattHelpers.BlockListStatus.ExcludeWrites);
-            var withResponse = (parameters["withResponse"]?.ToObject<bool>() ?? false) ||
+            var withResponse = parameters["withResponse"]?.ToObject<bool>() ??
                 !endpoint.CharacteristicProperties.HasFlag(GattCharacteristicProperties.WriteWithoutResponse);
 
             var result = await endpoint.WriteValueWithResultAsync(buffer.AsBuffer(),

--- a/macOS/Sources/scratch-link/BLESession.swift
+++ b/macOS/Sources/scratch-link/BLESession.swift
@@ -277,7 +277,7 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
 
     func write(withParams params: [String: Any], completion: @escaping JSONRPCCompletionHandler) throws {
         let buffer = try EncodingHelpers.decodeBuffer(fromJSON: params)
-        let withResponse = params["withResponse"] as? Bool ?? false
+        let withResponse = params["withResponse"] as? Bool
 
         getEndpoint(for: "write request", withParams: params, blockedBy: .ExcludeWrites) { endpoint, error in
             if let error = error {
@@ -297,7 +297,10 @@ class BLESession: Session, SwiftCBCentralManagerDelegate, SwiftCBPeripheralDeleg
                 return
             }
 
-            let writeType = (withResponse || !endpoint.properties.contains(.writeWithoutResponse)) ?
+            // If the client specified a write type, honor that.
+            // Otherwise, if the characteristic claims to support writing without response, do that.
+            // Otherwise, write with response.
+            let writeType = (withResponse ?? !endpoint.properties.contains(.writeWithoutResponse)) ?
                 CBCharacteristicWriteType.withResponse : CBCharacteristicWriteType.withoutResponse
             peripheral.writeValue(buffer, for: endpoint, type: writeType)
             completion(buffer.count, nil)


### PR DESCRIPTION
### Resolves

Resolves #150 
Closes #154

### Proposed Changes

In #154, @terado0618 implemented a fix for #150 on Windows. This PR includes #154 along with a similar change for macOS and documentation of the new behavior.

### Reason for Changes

This offers a significant performance boost on Windows: see [this comment](https://github.com/LLK/scratch-link/pull/154#issue-336024191). Performance on macOS seems to be acceptable without this change, but I think it's important for the hardware communication to be similar on both platforms so that extensions don't need to worry about platform differences.

This PR should be merged with LLK/scratch-vm#2298.

@terado0618, please let me know if you have concerns about this PR. Thanks!