### PR TITLE
Build for Windows on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,13 +43,10 @@ jobs:
           name: Build using MSBuild
           command: msbuild Windows/scratch-link.sln -m -p:Configuration=Release -p:Platform="Any CPU"
       - run:
-          name: Make artifacts directory
-          command: New-Item -Path Windows/ -Name Artifacts -ItemType directory
-      - run:
-          name: Move Microsoft Store APPX to artifacts directory
-          command: Move-Item -Path Windows/ScratchLinkAPPX/AppPackages/ScratchLinkAPPX_*_AnyCPU_bundle.appxupload -Destination Windows/Artifacts/
-      - run:
-          name: Move direct-download setup ZIP to artifacts directory
-          command: Move-Item -Path Windows/ScratchLinkSetup/bin/Release/ScratchLinkSetup-*.zip -Destination Windows/Artifacts/
+          name: Move build products to artifacts directory
+          command: |
+            New-Item -Path Windows/ -Name Artifacts -ItemType directory
+            Move-Item -Path Windows/ScratchLinkAPPX/AppPackages/ScratchLinkAPPX_*_AnyCPU_bundle.appxupload -Destination Windows/Artifacts/
+            Move-Item -Path Windows/ScratchLinkSetup/bin/Release/ScratchLinkSetup-*.zip -Destination Windows/Artifacts/
       - store_artifacts:
           path: Windows/Artifacts/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,9 @@ jobs:
           name: Install dependencies using NuGet
           command: nuget restore Windows/
       - run:
+          name: Import code-signing certificate
+          command: ./Windows/Import-WIN_CSC.ps1
+      - run:
           name: Build using MSBuild
           command: msbuild Windows/scratch-link.sln -m -p:Configuration=Release -p:Platform="Any CPU"
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 workflows:
-  macos:
-    jobs:
-      - build_for_mac
+#  macos:
+#    jobs:
+#      - build_for_mac
   windows:
     jobs:
       - build_for_windows:
@@ -10,18 +10,18 @@ workflows:
 orbs:
   windows: circleci/windows@2.2.0
 jobs:
-  build_for_mac:
-    macos:
-      xcode: "10.1.0"
-    steps:
-      - checkout
-      - run:
-          name: make dist
-          command: make --directory=macOS dist
-      - store_artifacts:
-          path: macOS/dist/scratch-link-*.pkg
-      - store_artifacts:
-          path: macOS/dist/mas-scratch-link-*.pkg
+#  build_for_mac:
+#    macos:
+#      xcode: "10.1.0"
+#    steps:
+#      - checkout
+#      - run:
+#          name: make dist
+#          command: make --directory=macOS dist
+#      - store_artifacts:
+#          path: macOS/dist/scratch-link-*.pkg
+#      - store_artifacts:
+#          path: macOS/dist/mas-scratch-link-*.pkg
   build_for_windows:
     executor: windows/default
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,16 +26,30 @@ jobs:
     executor: windows/default
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - nuget-cache-{{ checksum "Windows/scratch-link/packages.config" }}-{{ checksum "Windows/ScratchLinkSetup/packages.config" }}
       - run:
           name: Install dependencies using NuGet
           command: nuget restore Windows/
+      - save_cache:
+          paths:
+            - Windows/packages/
+          key: nuget-cache-{{ checksum "Windows/scratch-link/packages.config" }}-{{ checksum "Windows/ScratchLinkSetup/packages.config" }}
       - run:
           name: Import code-signing certificate
           command: ./Windows/Import-WIN_CSC.ps1
       - run:
           name: Build using MSBuild
           command: msbuild Windows/scratch-link.sln -m -p:Configuration=Release -p:Platform="Any CPU"
+      - run:
+          name: Make artifacts directory
+          command: New-Item -Path Windows/ -Name Artifacts -ItemType directory
+      - run:
+          name: Move Microsoft Store APPX to artifacts directory
+          command: Move-Item -Path Windows/ScratchLinkAPPX/AppPackages/ScratchLinkAPPX_*_AnyCPU_bundle.appxupload -Destination Windows/Artifacts/
+      - run:
+          name: Move direct-download setup ZIP to artifacts directory
+          command: Move-Item -Path Windows/ScratchLinkSetup/bin/Release/ScratchLinkSetup-*.zip -Destination Windows/Artifacts/
       - store_artifacts:
-          path: Windows/ScratchLinkSetup/bin/Release/ScratchLinkSetup-*.zip
-      - store_artifacts:
-          path: Windows/ScratchLinkAPPX/AppPackages/ScratchLinkAPPX_*_AnyCPU_bundle.appxupload
+          path: Windows/Artifacts/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,38 @@
+version: 2.1
+workflows:
+  macos:
+    jobs:
+      - build_for_mac
+  windows:
+    jobs:
+      - build_for_windows:
+          context: code-sign-generic
+orbs:
+  windows: circleci/windows@2.2.0
+jobs:
+  build_for_mac:
+    macos:
+      xcode: "10.1.0"
+    steps:
+      - checkout
+      - run:
+          name: make dist
+          command: make --directory=macOS dist
+      - store_artifacts:
+          path: macOS/dist/scratch-link-*.pkg
+      - store_artifacts:
+          path: macOS/dist/mas-scratch-link-*.pkg
+  build_for_windows:
+    executor: windows/default
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies using NuGet
+          command: nuget restore Windows/
+      - run:
+          name: Build using MSBuild
+          command: msbuild Windows/scratch-link.sln -m -p:Configuration=Release -p:Platform="Any CPU"
+      - store_artifacts:
+          path: Windows/ScratchLinkSetup/bin/Release/ScratchLinkSetup-*.zip
+      - store_artifacts:
+          path: Windows/ScratchLinkAPPX/AppPackages/ScratchLinkAPPX_*_AnyCPU_bundle.appxupload

--- a/README.md
+++ b/README.md
@@ -90,14 +90,16 @@ The Windows version of this project is in the `Windows` subdirectory.
 
 Prerequisites:
 
-* [Visual Studio 2017](https://visualstudio.microsoft.com/vs/) (Community Edition is sufficient)
+* [Visual Studio 2017 or newer](https://visualstudio.microsoft.com/vs/) (Community Edition is sufficient)
 * Windows 10.0.16299 SDK (install with Visual Studio)
-* [WiX Toolset](http://wixtoolset.org/releases/) (tested with 3.11.1)
-* [WiX Toolset Visual Studio Extension](
-  https://marketplace.visualstudio.com/items?itemName=RobMensching.WixToolsetVisualStudio2017Extension)
-  (tested with 0.9.21.62588)
+* Some of the Scratch Link project files depend on NuGet packages. Visual Studio should prompt you to install these
+  packages when you open the Solution file. Without these packages, Scratch Link may fail to build or run.
 
-Build, run, and debug by opening the Solution (`*.sln`) file in Visual Studio 2017.
+Optional:
+
+* [MSBuildStructuredLog](https://github.com/KirillOsenkov/MSBuildStructuredLog) is a huge help for debugging MSBuild.
+
+Build, run, and debug by opening the Solution (`*.sln`) file in Visual Studio.
 
 #### Signing the MSI installer
 

--- a/Windows/.gitattributes
+++ b/Windows/.gitattributes
@@ -17,6 +17,7 @@
 *.config text eol=crlf
 *.cs text eol=crlf
 *.csproj text eol=crlf
+*.ps1 text eol=crlf
 *.resx text eol=crlf
 *.settings text eol=crlf
 *.sln text eol=crlf

--- a/Windows/Import-WIN_CSC.ps1
+++ b/Windows/Import-WIN_CSC.ps1
@@ -5,8 +5,7 @@
     This command assumes two environment variables:
       - WIN_CSC_LINK is assumed to contain one or more Base64-encoded, encrypted digital certificate(s) and/or key(s).
       - WIN_CSC_KEY_PASSWORD is assumed to contain the password necessary to decrypt the data in WIN_CSC_LINK.
-        The script will import the contents of WIN_CSC_LINK into the current user's "Personal" certificate store or
-        that of the local machine, depending on permissions.
+        The script will import the contents of WIN_CSC_LINK into the local machine's "Personal" certificate store.
 .NOTES
     This is designed for use with a continuous integration service which places sensitive information, like digital
     certificates, into environment variables. It may not work well for other purposes.
@@ -22,13 +21,7 @@ try {
 
     $securePassword = (ConvertTo-SecureString -String $env:WIN_CSC_KEY_PASSWORD -AsPlainText -Force)
 
-    try {
-        Import-PfxCertificate -FilePath $tempPfx -Password $securePassword -CertStoreLocation "Cert:/CurrentUser/My"
-    } catch [System.Runtime.InteropServices.COMException] {
-        # Probably "Access Denied" above. It seems like "Run as Administrator" doesn't allow access to the user's
-        # certificate store, or something like that.
-        Import-PfxCertificate -FilePath $tempPfx -Password $securePassword -CertStoreLocation "Cert:/LocalMachine/My"
-    }
+    Import-PfxCertificate -FilePath $tempPfx -Password $securePassword -CertStoreLocation "Cert:/LocalMachine/My"
 }
 finally {
     Remove-Item -Force $tempPfx

--- a/Windows/Import-WIN_CSC.ps1
+++ b/Windows/Import-WIN_CSC.ps1
@@ -1,0 +1,35 @@
+<#
+.SYNOPSIS
+    Import one or more digital certificate(s) and private key(s) from WIN_CSC_* environment variables.
+.DESCRIPTION
+    This command assumes two environment variables:
+      - WIN_CSC_LINK is assumed to contain one or more Base64-encoded, encrypted digital certificate(s) and/or key(s).
+      - WIN_CSC_KEY_PASSWORD is assumed to contain the password necessary to decrypt the data in WIN_CSC_LINK.
+        The script will import the contents of WIN_CSC_LINK into the current user's "Personal" certificate store or
+        that of the local machine, depending on permissions.
+.NOTES
+    This is designed for use with a continuous integration service which places sensitive information, like digital
+    certificates, into environment variables. It may not work well for other purposes.
+    The data in WIN_CSC_LINK most likely will need to contain intermediates.
+#>
+
+$ErrorActionPreference = "Stop"
+
+# TODO: is there a way to avoid creating a temporary file?
+$tempPfx = New-TemporaryFile
+try {
+    $env:WIN_CSC_LINK | Set-Content $tempPfx
+
+    $securePassword = (ConvertTo-SecureString -String $env:WIN_CSC_KEY_PASSWORD -AsPlainText -Force)
+
+    try {
+        Import-PfxCertificate -FilePath $tempPfx -Password $securePassword -CertStoreLocation "Cert:/CurrentUser/My"
+    } catch [System.Runtime.InteropServices.COMException] {
+        # Probably "Access Denied" above. It seems like "Run as Administrator" doesn't allow access to the user's
+        # certificate store, or something like that.
+        Import-PfxCertificate -FilePath $tempPfx -Password $securePassword -CertStoreLocation "Cert:/LocalMachine/My"
+    }
+}
+finally {
+    Remove-Item -Force $tempPfx
+}

--- a/Windows/ScratchLinkAPPX/ScratchLinkAPPX.wapproj
+++ b/Windows/ScratchLinkAPPX/ScratchLinkAPPX.wapproj
@@ -22,7 +22,6 @@
     <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
-    <PackageCertificateKeyFile>ScratchLink_StoreKey.pfx</PackageCertificateKeyFile>
     <EntryPointProjectUniqueName>..\scratch-link\ScratchLink.csproj</EntryPointProjectUniqueName>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
     <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
@@ -32,6 +31,7 @@
     <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
     <GenerateTestArtifacts>True</GenerateTestArtifacts>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
+    <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AppxBundle>Always</AppxBundle>
@@ -90,7 +90,6 @@
     <Content Include="Images\Wide310x150Logo.scale-150.png" />
     <Content Include="Images\Wide310x150Logo.scale-200.png" />
     <Content Include="Images\Wide310x150Logo.scale-400.png" />
-    <None Include="ScratchLink_StoreKey.pfx" />
     <None Include="Package.StoreAssociation.xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Windows/ScratchLinkSetup/ScratchLinkSetup.wixproj
+++ b/Windows/ScratchLinkSetup/ScratchLinkSetup.wixproj
@@ -60,7 +60,7 @@
 	-->
   <Import Project="..\msiZipWithVersion.targets" />
   <PropertyGroup>
-    <PostBuildEvent>$(SignToolPath)signtool.exe sign /v /a /sha1 fafb6925eba28dcdce5440f3c2b79616f7b597e8 /t http://timestamp.digicert.com /d "Scratch Link" !(TargetPath)</PostBuildEvent>
+    <PostBuildEvent>$(SignToolPath)signtool.exe sign /debug /v /a /sha1 fafb6925eba28dcdce5440f3c2b79616f7b597e8 /t http://timestamp.digicert.com /d "Scratch Link" !(TargetPath)</PostBuildEvent>
   </PropertyGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/Windows/ScratchLinkSetup/ScratchLinkSetup.wixproj
+++ b/Windows/ScratchLinkSetup/ScratchLinkSetup.wixproj
@@ -44,11 +44,11 @@
     <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
   </Target>
   <PropertyGroup>
-    <WindowsKitsRoot>$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots', 'KitsRoot10', null, RegistryView.Registry32, RegistryView.Default))</WindowsKitsRoot>
-    <WindowsKitsRoot Condition="'$(WindowsKitsRoot)' == ''">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots', 'KitsRoot81', null, RegistryView.Registry32, RegistryView.Default))</WindowsKitsRoot>
-    <WindowsKitsRoot Condition="'$(WindowsKitsRoot)' == ''">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots', 'KitsRoot', null, RegistryView.Registry32, RegistryView.Default))</WindowsKitsRoot>
-    <SignToolPath Condition=" '$(SignToolPath)' == '' And '$(Platform)' == 'AnyCPU' ">"$(WindowsKitsRoot)bin\x86\"</SignToolPath>
-    <SignToolPath Condition="'$(SignToolPath)' == ''">"$(WindowsKitsRoot)bin\$(Platform)\"</SignToolPath>
+    <WindowsKitsRoot Condition="'$(WindowsKitsRoot)' == ''">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots', 'KitsRoot10', null, RegistryView.Registry32, RegistryView.Default))</WindowsKitsRoot>
+    <SignToolPath Condition="'$(WindowsKitsRoot)' != '' And '$(SignToolPath)' == '' And exists('$(WindowsKitsRoot)bin\10.0.18362.0\')">$(WindowsKitsRoot)bin\10.0.18362.0\$(Platform)\</SignToolPath>
+    <SignToolPath Condition="'$(WindowsKitsRoot)' != '' And '$(SignToolPath)' == '' And exists('$(WindowsKitsRoot)bin\10.0.17763.0\')">$(WindowsKitsRoot)bin\10.0.17763.0\$(Platform)\</SignToolPath>
+    <SignToolPath Condition="'$(WindowsKitsRoot)' != '' And '$(SignToolPath)' == '' And exists('$(WindowsKitsRoot)bin\10.0.17134.0\')">$(WindowsKitsRoot)bin\10.0.17134.0\$(Platform)\</SignToolPath>
+    <SignToolPath Condition="'$(WindowsKitsRoot)' != '' And '$(SignToolPath)' == '' And exists('$(WindowsKitsRoot)bin\10.0.16299.0\')">$(WindowsKitsRoot)bin\10.0.16299.0\$(Platform)\</SignToolPath>
   </PropertyGroup>
   <!--
 	To modify your build process, add your task inside one of the targets below and uncomment it.
@@ -60,7 +60,7 @@
 	-->
   <Import Project="..\msiZipWithVersion.targets" />
   <PropertyGroup>
-    <PostBuildEvent>$(SignToolPath)signtool.exe sign /debug /v /a /sha1 fafb6925eba28dcdce5440f3c2b79616f7b597e8 /t http://timestamp.digicert.com /d "Scratch Link" !(TargetPath)</PostBuildEvent>
+    <PostBuildEvent>"$(SignToolPath)signtool.exe" sign /debug /v /a /sm /sha1 fafb6925eba28dcdce5440f3c2b79616f7b597e8 /t http://timestamp.digicert.com /d "Scratch Link" !(TargetPath)</PostBuildEvent>
   </PropertyGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/Windows/ScratchLinkSetup/ScratchLinkSetup.wixproj
+++ b/Windows/ScratchLinkSetup/ScratchLinkSetup.wixproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" InitialTargets="EnsureWixToolsetInstalled" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\WiX.3.11.2\build\wix.props" Condition="Exists('..\packages\WiX.3.11.2\build\wix.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -8,6 +9,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <OutputName>ScratchLinkSetup</OutputName>
     <OutputType>Package</OutputType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>
@@ -31,6 +34,9 @@
       <RefProjectOutputGroups>Binaries;Content;Satellites</RefProjectOutputGroups>
       <RefTargetDir>INSTALLFOLDER</RefTargetDir>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="packages.config" />
   </ItemGroup>
   <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
@@ -56,4 +62,10 @@
   <PropertyGroup>
     <PostBuildEvent>$(SignToolPath)signtool.exe sign /v /a /sha1 fafb6925eba28dcdce5440f3c2b79616f7b597e8 /t http://timestamp.digicert.com /d "Scratch Link" !(TargetPath)</PostBuildEvent>
   </PropertyGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\WiX.3.11.2\build\wix.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\WiX.3.11.2\build\wix.props'))" />
+  </Target>
 </Project>

--- a/Windows/ScratchLinkSetup/packages.config
+++ b/Windows/ScratchLinkSetup/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WiX" version="3.11.2" />
+</packages>

--- a/Windows/msiZipWithVersion.targets
+++ b/Windows/msiZipWithVersion.targets
@@ -3,6 +3,7 @@ Assuming the output of your project is an MSI file, put it into a ZIP whose name
 This is designed to be used from a WiX project.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)packages\WiX.3.11.2\build\wix.props" />
   <UsingTask TaskName="msiGetVersion" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
     <ParameterGroup>
       <!-- Input -->
@@ -11,7 +12,7 @@ This is designed to be used from a WiX project.
       <ProductVersion ParameterType="System.String" Output="true"/>
     </ParameterGroup>
     <Task>
-      <Reference Include="$(WIX)bin\Microsoft.Deployment.WindowsInstaller.dll"/>
+      <Reference Include="$(WixInstallPath)\Microsoft.Deployment.WindowsInstaller.dll"/>
       <Using Namespace="Microsoft.Deployment.WindowsInstaller"/>
       <Code Type="Fragment" Language="cs"><![CDATA[
         using (var msi = new Database(FilePath))

--- a/Windows/scratch-link.sln
+++ b/Windows/scratch-link.sln
@@ -10,6 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
 		generate-images.sh = generate-images.sh
+		Import-WIN_CSC.ps1 = Import-WIN_CSC.ps1
 		msiZipWithVersion.targets = msiZipWithVersion.targets
 		..\playground.html = ..\playground.html
 		..\README.md = ..\README.md

--- a/Windows/scratch-link.sln
+++ b/Windows/scratch-link.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27428.2037
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29509.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScratchLink", "scratch-link\ScratchLink.csproj", "{711F5DBA-7A5D-447A-A9BA-50CB2096E00A}"
 EndProject
@@ -28,6 +28,11 @@ Project("{C7167F0D-BC9F-4E6E-AFE1-012C56B48DB5}") = "ScratchLinkAPPX", "ScratchL
 EndProject
 Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "ScratchLinkSetup", "ScratchLinkSetup\ScratchLinkSetup.wixproj", "{5AC1AA26-9C7C-4A81-99B7-21222DA0D89E}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".circleci", ".circleci", "{2E316847-3325-4060-9560-ED29CF3D1156}"
+	ProjectSection(SolutionItems) = preProject
+		..\.circleci\config.yml = ..\.circleci\config.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +56,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{3721552C-638C-48CC-A154-F995CEA87505} = {56ED428E-4406-49E4-A454-B5B8EE848E66}
+		{2E316847-3325-4060-9560-ED29CF3D1156} = {56ED428E-4406-49E4-A454-B5B8EE848E66}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8DE7771A-9DD3-44DD-AA08-46514DA0F673}


### PR DESCRIPTION
### Proposed Changes

This PR adds a CircleCI configuration for building the Windows version of Scratch Link on CircleCI. There's also a stub macOS configuration but it's untested so far.

There are a few supporting changes mixed in as well, all of which are (IMO) positive changes on their own. These changes should make Scratch Link build without configuration changes on a wider variety of systems. These include:
- The ScratchLinkAPPX project no longer digitally signs its output with a test certificate assumed to be present in `ScratchLink_StoreKey.pfx`. This step was unnecessary since the Microsoft Store signs the build on its own after submission.
- The ScratchLinkSetup project now depends on WiX through NuGet instead of requiring it to be pre-installed on the system.
- The ScratchLinkSetup project now searches in more places for `signtool.exe`, including all current Windows 10 SDK locations.
