### PR TITLE
Windows: display which program is causing port conflict

### DIFF
--- a/Windows/scratch-link/App.cs
+++ b/Windows/scratch-link/App.cs
@@ -12,7 +12,7 @@ namespace scratch_link
 {
     public class App : ApplicationContext
     {
-        const int SDMPort = 20110;
+        public const int SDMPort = 20110;
 
         private static class SDMPath
         {
@@ -89,17 +89,10 @@ namespace scratch_link
         {
             PrepareToClose();
 
-            var title = "Address already in use!";
-            var body = String.Format(
-                "{0} was unable to start because port {1} is already in use.\n" +
-                "\n" +
-                "This means {0} is already running or another application is using that port.\n" +
-                "\n" +
-                "This application will now exit.",
-                scratch_link.Properties.Resources.AppTitle,
-                SDMPort
-            );
-            MessageBox.Show(body, title, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            using (var dialog = new Dialogs.AddressInUse())
+            {
+                dialog.ShowDialog();
+            }
 
             Environment.Exit(1);
         }

--- a/Windows/scratch-link/Dialogs/AddressInUse.Designer.cs
+++ b/Windows/scratch-link/Dialogs/AddressInUse.Designer.cs
@@ -34,9 +34,9 @@ namespace scratch_link.Dialogs
             this.CloseButton = new System.Windows.Forms.Button();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.listView1 = new System.Windows.Forms.ListView();
-            this.processName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.processId = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.label2 = new System.Windows.Forms.Label();
+            this.propertyColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.valueColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.labelNoResults = new System.Windows.Forms.Label();
             this.CopyButton = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             this.panel1.SuspendLayout();
@@ -98,7 +98,7 @@ namespace scratch_link.Dialogs
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.groupBox1.Controls.Add(this.listView1);
-            this.groupBox1.Controls.Add(this.label2);
+            this.groupBox1.Controls.Add(this.labelNoResults);
             this.groupBox1.Location = new System.Drawing.Point(12, 111);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Size = new System.Drawing.Size(386, 116);
@@ -108,42 +108,43 @@ namespace scratch_link.Dialogs
             // 
             // listView1
             // 
-            this.listView1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
             this.listView1.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.processName,
-            this.processId});
+            this.propertyColumn,
+            this.valueColumn});
             this.listView1.FullRowSelect = true;
             this.listView1.GridLines = true;
+            this.listView1.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
             this.listView1.HideSelection = false;
             this.listView1.Location = new System.Drawing.Point(6, 19);
             this.listView1.Name = "listView1";
-            this.listView1.Size = new System.Drawing.Size(374, 75);
+            this.listView1.Size = new System.Drawing.Size(374, 91);
             this.listView1.TabIndex = 1;
             this.listView1.UseCompatibleStateImageBehavior = false;
             this.listView1.View = System.Windows.Forms.View.Details;
             // 
-            // processName
+            // propertyColumn
             // 
-            this.processName.Text = "Process Name";
-            this.processName.Width = 286;
+            this.propertyColumn.Text = "Property";
+            this.propertyColumn.Width = 83;
             // 
-            // processId
+            // valueColumn
             // 
-            this.processId.Text = "Process ID";
-            this.processId.Width = 64;
+            this.valueColumn.Text = "Value";
+            this.valueColumn.Width = 281;
             // 
-            // label2
+            // labelNoResults
             // 
-            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.label2.AutoSize = true;
-            this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(6, 97);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(368, 13);
-            this.label2.TabIndex = 0;
-            this.label2.Text = "Some details may be missing if this application is not running as Administrator.";
+            this.labelNoResults.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelNoResults.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelNoResults.Location = new System.Drawing.Point(6, 19);
+            this.labelNoResults.Margin = new System.Windows.Forms.Padding(3);
+            this.labelNoResults.Name = "labelNoResults";
+            this.labelNoResults.Size = new System.Drawing.Size(374, 91);
+            this.labelNoResults.TabIndex = 0;
+            this.labelNoResults.Text = "Could not collect details. Running as Administrator might help.";
+            this.labelNoResults.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // CopyButton
             // 
@@ -180,7 +181,6 @@ namespace scratch_link.Dialogs
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             this.panel1.ResumeLayout(false);
             this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -194,9 +194,9 @@ namespace scratch_link.Dialogs
         private System.Windows.Forms.Button CloseButton;
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.ListView listView1;
-        private System.Windows.Forms.ColumnHeader processName;
-        private System.Windows.Forms.ColumnHeader processId;
-        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.ColumnHeader propertyColumn;
+        private System.Windows.Forms.ColumnHeader valueColumn;
+        private System.Windows.Forms.Label labelNoResults;
         private System.Windows.Forms.Button CopyButton;
     }
 }

--- a/Windows/scratch-link/Dialogs/AddressInUse.Designer.cs
+++ b/Windows/scratch-link/Dialogs/AddressInUse.Designer.cs
@@ -32,7 +32,7 @@ namespace scratch_link.Dialogs
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
             this.panel1 = new System.Windows.Forms.Panel();
             this.CloseButton = new System.Windows.Forms.Button();
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.detailsBox = new System.Windows.Forms.GroupBox();
             this.listView1 = new System.Windows.Forms.ListView();
             this.propertyColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.valueColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -40,7 +40,7 @@ namespace scratch_link.Dialogs
             this.CopyButton = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             this.panel1.SuspendLayout();
-            this.groupBox1.SuspendLayout();
+            this.detailsBox.SuspendLayout();
             this.SuspendLayout();
             // 
             // label1
@@ -91,20 +91,20 @@ namespace scratch_link.Dialogs
             this.CloseButton.UseVisualStyleBackColor = true;
             this.CloseButton.Click += new System.EventHandler(this.CloseButton_Click);
             // 
-            // groupBox1
+            // detailsBox
             // 
-            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.detailsBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBox1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.groupBox1.Controls.Add(this.listView1);
-            this.groupBox1.Controls.Add(this.labelNoResults);
-            this.groupBox1.Location = new System.Drawing.Point(12, 111);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(386, 116);
-            this.groupBox1.TabIndex = 4;
-            this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Details";
+            this.detailsBox.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.detailsBox.Controls.Add(this.listView1);
+            this.detailsBox.Controls.Add(this.labelNoResults);
+            this.detailsBox.Location = new System.Drawing.Point(12, 111);
+            this.detailsBox.Name = "detailsBox";
+            this.detailsBox.Size = new System.Drawing.Size(386, 116);
+            this.detailsBox.TabIndex = 4;
+            this.detailsBox.TabStop = false;
+            this.detailsBox.Text = "Details about the conflicting program";
             // 
             // listView1
             // 
@@ -168,7 +168,7 @@ namespace scratch_link.Dialogs
             this.CancelButton = this.CloseButton;
             this.ClientSize = new System.Drawing.Size(410, 268);
             this.Controls.Add(this.CopyButton);
-            this.Controls.Add(this.groupBox1);
+            this.Controls.Add(this.detailsBox);
             this.Controls.Add(this.CloseButton);
             this.Controls.Add(this.panel1);
             this.MaximizeBox = false;
@@ -180,7 +180,7 @@ namespace scratch_link.Dialogs
             this.TopMost = true;
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             this.panel1.ResumeLayout(false);
-            this.groupBox1.ResumeLayout(false);
+            this.detailsBox.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -192,7 +192,7 @@ namespace scratch_link.Dialogs
         private System.Windows.Forms.PictureBox pictureBox1;
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.Button CloseButton;
-        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.GroupBox detailsBox;
         private System.Windows.Forms.ListView listView1;
         private System.Windows.Forms.ColumnHeader propertyColumn;
         private System.Windows.Forms.ColumnHeader valueColumn;

--- a/Windows/scratch-link/Dialogs/AddressInUse.Designer.cs
+++ b/Windows/scratch-link/Dialogs/AddressInUse.Designer.cs
@@ -31,12 +31,13 @@ namespace scratch_link.Dialogs
             this.label1 = new System.Windows.Forms.Label();
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
             this.panel1 = new System.Windows.Forms.Panel();
-            this.OkButton = new System.Windows.Forms.Button();
+            this.CloseButton = new System.Windows.Forms.Button();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.listView1 = new System.Windows.Forms.ListView();
             this.processName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.processId = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.label2 = new System.Windows.Forms.Label();
+            this.CopyButton = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             this.panel1.SuspendLayout();
             this.groupBox1.SuspendLayout();
@@ -78,16 +79,17 @@ namespace scratch_link.Dialogs
             this.panel1.Size = new System.Drawing.Size(410, 105);
             this.panel1.TabIndex = 2;
             // 
-            // OkButton
+            // CloseButton
             // 
-            this.OkButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.OkButton.Location = new System.Drawing.Point(323, 233);
-            this.OkButton.Name = "OkButton";
-            this.OkButton.Size = new System.Drawing.Size(75, 23);
-            this.OkButton.TabIndex = 3;
-            this.OkButton.Text = "OK";
-            this.OkButton.UseVisualStyleBackColor = true;
-            this.OkButton.Click += new System.EventHandler(this.button1_Click);
+            this.CloseButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.CloseButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.CloseButton.Location = new System.Drawing.Point(323, 233);
+            this.CloseButton.Name = "CloseButton";
+            this.CloseButton.Size = new System.Drawing.Size(75, 23);
+            this.CloseButton.TabIndex = 3;
+            this.CloseButton.Text = "Close";
+            this.CloseButton.UseVisualStyleBackColor = true;
+            this.CloseButton.Click += new System.EventHandler(this.CloseButton_Click);
             // 
             // groupBox1
             // 
@@ -112,7 +114,9 @@ namespace scratch_link.Dialogs
             this.listView1.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.processName,
             this.processId});
+            this.listView1.FullRowSelect = true;
             this.listView1.GridLines = true;
+            this.listView1.HideSelection = false;
             this.listView1.Location = new System.Drawing.Point(6, 19);
             this.listView1.Name = "listView1";
             this.listView1.Size = new System.Drawing.Size(374, 75);
@@ -141,17 +145,30 @@ namespace scratch_link.Dialogs
             this.label2.TabIndex = 0;
             this.label2.Text = "Some details may be missing if this application is not running as Administrator.";
             // 
+            // CopyButton
+            // 
+            this.CopyButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.CopyButton.Location = new System.Drawing.Point(242, 233);
+            this.CopyButton.Name = "CopyButton";
+            this.CopyButton.Size = new System.Drawing.Size(75, 23);
+            this.CopyButton.TabIndex = 5;
+            this.CopyButton.Text = "Copy";
+            this.CopyButton.UseVisualStyleBackColor = true;
+            this.CopyButton.Click += new System.EventHandler(this.CopyButton_Click);
+            // 
             // AddressInUse
             // 
-            this.AcceptButton = this.OkButton;
+            this.AcceptButton = this.CloseButton;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.BackColor = System.Drawing.SystemColors.Control;
+            this.CancelButton = this.CloseButton;
             this.ClientSize = new System.Drawing.Size(410, 268);
+            this.Controls.Add(this.CopyButton);
             this.Controls.Add(this.groupBox1);
-            this.Controls.Add(this.OkButton);
+            this.Controls.Add(this.CloseButton);
             this.Controls.Add(this.panel1);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
@@ -174,11 +191,12 @@ namespace scratch_link.Dialogs
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.PictureBox pictureBox1;
         private System.Windows.Forms.Panel panel1;
-        private System.Windows.Forms.Button OkButton;
+        private System.Windows.Forms.Button CloseButton;
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.ListView listView1;
         private System.Windows.Forms.ColumnHeader processName;
         private System.Windows.Forms.ColumnHeader processId;
         private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Button CopyButton;
     }
 }

--- a/Windows/scratch-link/Dialogs/AddressInUse.Designer.cs
+++ b/Windows/scratch-link/Dialogs/AddressInUse.Designer.cs
@@ -1,0 +1,184 @@
+namespace scratch_link.Dialogs
+{
+    partial class AddressInUse
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.label1 = new System.Windows.Forms.Label();
+            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.OkButton = new System.Windows.Forms.Button();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.listView1 = new System.Windows.Forms.ListView();
+            this.processName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.processId = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.label2 = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            this.panel1.SuspendLayout();
+            this.groupBox1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // label1
+            // 
+            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.label1.Location = new System.Drawing.Point(50, 12);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(348, 80);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "This application was unable to start because its port is already in use.\r\n\r\nThis " +
+    "means the application is already running or another application is using that po" +
+    "rt.\r\n\r\nThis application will now exit.";
+            // 
+            // pictureBox1
+            // 
+            this.pictureBox1.Location = new System.Drawing.Point(12, 12);
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.Size = new System.Drawing.Size(32, 32);
+            this.pictureBox1.TabIndex = 1;
+            this.pictureBox1.TabStop = false;
+            // 
+            // panel1
+            // 
+            this.panel1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.panel1.AutoSize = true;
+            this.panel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.panel1.BackColor = System.Drawing.SystemColors.Window;
+            this.panel1.Controls.Add(this.pictureBox1);
+            this.panel1.Controls.Add(this.label1);
+            this.panel1.Location = new System.Drawing.Point(0, 0);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(410, 105);
+            this.panel1.TabIndex = 2;
+            // 
+            // OkButton
+            // 
+            this.OkButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.OkButton.Location = new System.Drawing.Point(323, 233);
+            this.OkButton.Name = "OkButton";
+            this.OkButton.Size = new System.Drawing.Size(75, 23);
+            this.OkButton.TabIndex = 3;
+            this.OkButton.Text = "OK";
+            this.OkButton.UseVisualStyleBackColor = true;
+            this.OkButton.Click += new System.EventHandler(this.button1_Click);
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.groupBox1.Controls.Add(this.listView1);
+            this.groupBox1.Controls.Add(this.label2);
+            this.groupBox1.Location = new System.Drawing.Point(12, 111);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(386, 116);
+            this.groupBox1.TabIndex = 4;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Details";
+            // 
+            // listView1
+            // 
+            this.listView1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.listView1.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.processName,
+            this.processId});
+            this.listView1.GridLines = true;
+            this.listView1.Location = new System.Drawing.Point(6, 19);
+            this.listView1.Name = "listView1";
+            this.listView1.Size = new System.Drawing.Size(374, 75);
+            this.listView1.TabIndex = 1;
+            this.listView1.UseCompatibleStateImageBehavior = false;
+            this.listView1.View = System.Windows.Forms.View.Details;
+            // 
+            // processName
+            // 
+            this.processName.Text = "Process Name";
+            this.processName.Width = 286;
+            // 
+            // processId
+            // 
+            this.processId.Text = "Process ID";
+            this.processId.Width = 64;
+            // 
+            // label2
+            // 
+            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.label2.AutoSize = true;
+            this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label2.Location = new System.Drawing.Point(6, 97);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(368, 13);
+            this.label2.TabIndex = 0;
+            this.label2.Text = "Some details may be missing if this application is not running as Administrator.";
+            // 
+            // AddressInUse
+            // 
+            this.AcceptButton = this.OkButton;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoSize = true;
+            this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.BackColor = System.Drawing.SystemColors.Control;
+            this.ClientSize = new System.Drawing.Size(410, 268);
+            this.Controls.Add(this.groupBox1);
+            this.Controls.Add(this.OkButton);
+            this.Controls.Add(this.panel1);
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "AddressInUse";
+            this.ShowIcon = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Address already in use!";
+            this.TopMost = true;
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            this.panel1.ResumeLayout(false);
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.Panel panel1;
+        private System.Windows.Forms.Button OkButton;
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.ListView listView1;
+        private System.Windows.Forms.ColumnHeader processName;
+        private System.Windows.Forms.ColumnHeader processId;
+        private System.Windows.Forms.Label label2;
+    }
+}

--- a/Windows/scratch-link/Dialogs/AddressInUse.cs
+++ b/Windows/scratch-link/Dialogs/AddressInUse.cs
@@ -1,24 +1,21 @@
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Diagnostics;
 using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace scratch_link.Dialogs
 {
     public partial class AddressInUse : Form
     {
+        string textContent;
+
         public AddressInUse()
         {
             InitializeComponent();
 
             pictureBox1.Image = SystemIcons.Error.ToBitmap();
-            label1.Text = String.Format(
+
+            textContent = string.Format(
                 "{0} was unable to start because port {1} is already in use.\n" +
                 "\n" +
                 "This means {0} is already running or another application is using that port.\n" +
@@ -27,6 +24,9 @@ namespace scratch_link.Dialogs
                 scratch_link.Properties.Resources.AppTitle,
                 App.SDMPort
             );
+            label1.Text = textContent;
+
+            textContent += "\n\nDetails:\n PID \tProcess Name\n";
 
             var pid = Fiddler.Winsock.MapLocalPortToProcessId(App.SDMPort);
             if (pid > 0)
@@ -34,12 +34,18 @@ namespace scratch_link.Dialogs
                 var process = Process.GetProcessById(pid);
                 var item = new ListViewItem(new [] { process.ProcessName, pid.ToString() });
                 listView1.Items.Add(item);
+                textContent += pid.ToString() + '\t' + process.ProcessName + '\n';
             }
         }
 
-        private void button1_Click(object sender, EventArgs e)
+        private void CloseButton_Click(object sender, EventArgs e)
         {
             Close();
+        }
+
+        private void CopyButton_Click(object sender, EventArgs e)
+        {
+            Clipboard.SetText(textContent);
         }
     }
 }

--- a/Windows/scratch-link/Dialogs/AddressInUse.cs
+++ b/Windows/scratch-link/Dialogs/AddressInUse.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Diagnostics;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace scratch_link.Dialogs
+{
+    public partial class AddressInUse : Form
+    {
+        public AddressInUse()
+        {
+            InitializeComponent();
+
+            pictureBox1.Image = SystemIcons.Error.ToBitmap();
+            label1.Text = String.Format(
+                "{0} was unable to start because port {1} is already in use.\n" +
+                "\n" +
+                "This means {0} is already running or another application is using that port.\n" +
+                "\n" +
+                "This application will now exit.",
+                scratch_link.Properties.Resources.AppTitle,
+                App.SDMPort
+            );
+
+            var pid = Fiddler.Winsock.MapLocalPortToProcessId(App.SDMPort);
+            if (pid > 0)
+            {
+                var process = Process.GetProcessById(pid);
+                var item = new ListViewItem(new [] { process.ProcessName, pid.ToString() });
+                listView1.Items.Add(item);
+            }
+        }
+
+        private void button1_Click(object sender, EventArgs e)
+        {
+            Close();
+        }
+    }
+}

--- a/Windows/scratch-link/Dialogs/AddressInUse.cs
+++ b/Windows/scratch-link/Dialogs/AddressInUse.cs
@@ -26,16 +26,32 @@ namespace scratch_link.Dialogs
             );
             label1.Text = textContent;
 
-            textContent += "\n\nDetails:\n PID \tProcess Name\n";
+            textContent += "\n\nDetails:\n";
 
             var pid = Fiddler.Winsock.MapLocalPortToProcessId(App.SDMPort);
             if (pid > 0)
             {
                 var process = Process.GetProcessById(pid);
-                var item = new ListViewItem(new [] { process.ProcessName, pid.ToString() });
-                listView1.Items.Add(item);
-                textContent += pid.ToString() + '\t' + process.ProcessName + '\n';
+                AddProcessPropertyValue("Process Name", process.ProcessName);
+                AddProcessPropertyValue("Window Title", process.MainWindowTitle);
+                AddProcessPropertyValue("File Name", process.MainModule.FileName);
+                AddProcessPropertyValue("Process ID", pid.ToString());
+                AddProcessPropertyValue("TCP Port", App.SDMPort.ToString());
+                labelNoResults.Visible = false;
+                listView1.Visible = true;
             }
+            else
+            {
+                textContent += labelNoResults.Text + '\n';
+                labelNoResults.Visible = true;
+                listView1.Visible = false;
+            }
+        }
+
+        private void AddProcessPropertyValue(string property, string value)
+        {
+            listView1.Items.Add(new ListViewItem(new[] { property, value }));
+            textContent += property + ":\t" + value + "\n";
         }
 
         private void CloseButton_Click(object sender, EventArgs e)

--- a/Windows/scratch-link/Dialogs/AddressInUse.cs
+++ b/Windows/scratch-link/Dialogs/AddressInUse.cs
@@ -26,7 +26,8 @@ namespace scratch_link.Dialogs
             );
             label1.Text = textContent;
 
-            textContent += "\n\nDetails:\n";
+            // detailsBox.Text is the label for the group box around the details
+            textContent += "\n\n" + detailsBox.Text + ":\n";
 
             var pid = Fiddler.Winsock.MapLocalPortToProcessId(App.SDMPort);
             if (pid > 0)

--- a/Windows/scratch-link/Dialogs/AddressInUse.resx
+++ b/Windows/scratch-link/Dialogs/AddressInUse.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Windows/scratch-link/ScratchLink.csproj
+++ b/Windows/scratch-link/ScratchLink.csproj
@@ -66,6 +66,12 @@
   <ItemGroup>
     <Compile Include="AssemblyExtensions.cs" />
     <Compile Include="BLESession.cs" />
+    <Compile Include="Dialogs\AddressInUse.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Dialogs\AddressInUse.Designer.cs">
+      <DependentUpon>AddressInUse.cs</DependentUpon>
+    </Compile>
     <Compile Include="EncodingHelpers.cs" />
     <Compile Include="GattHelpers.cs" />
     <Compile Include="BTSession.cs" />
@@ -85,6 +91,10 @@
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
     <Compile Include="Program.cs" />
+    <Compile Include="Util\FiddlerWinsock.cs" />
+    <EmbeddedResource Include="Dialogs\AddressInUse.resx">
+      <DependentUpon>AddressInUse.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/Windows/scratch-link/Util/FiddlerWinsock.cs
+++ b/Windows/scratch-link/Util/FiddlerWinsock.cs
@@ -1,0 +1,208 @@
+﻿// This sample is provided "AS IS" and confers no warranties.
+// You are granted a non-exclusive, worldwide, royalty-free license to reproduce this code,
+// prepare derivative works, and distribute it or any derivative works that you create.
+//
+// This class invokes the Windows IPHelper APIs that allow us to map sockets to processes.
+// See http://www.pinvoke.net/default.aspx/iphlpapi/GetExtendedTcpTable.html as a reference
+//
+// We could consider a cache of recent hits to improve performance, but the performance is already pretty good, and 
+// creating a reasonable cache expiration policy could prove tricky. Client connection reuse already provides a significant
+// optimization as it behaves in the same way as an explicit cache would.
+// 
+using System;
+using System.Runtime.InteropServices;
+using System.Diagnostics;
+
+namespace Fiddler
+{
+    internal class Winsock
+    {
+        #region IPHelper_PInvokes
+
+        private const int AF_INET = 2;              // IPv4
+        private const int AF_INET6 = 23;            // IPv6
+        private const int ERROR_INSUFFICIENT_BUFFER = 0x7a;
+        private const int NO_ERROR = 0x0;
+
+        // Learn about IPHelper here: http://msdn2.microsoft.com/en-us/library/aa366073.aspx and http://msdn2.microsoft.com/en-us/library/aa365928.aspx
+        // Note: C++'s ulong is ALWAYS 32bits, unlike C#'s ulong. See http://medo64.blogspot.com/2009/05/why-ulong-is-32-bit-even-on-64-bit.html
+        [DllImport("iphlpapi.dll", ExactSpelling = true, SetLastError = true)]
+        private static extern uint GetExtendedTcpTable(IntPtr pTcpTable, ref UInt32 dwTcpTableLength, [MarshalAs(UnmanagedType.Bool)] bool sort, UInt32 ipVersion, TcpTableType tcpTableType, UInt32 reserved);
+
+        /// <summary>
+        /// Enumeration of possible queries that can be issued using GetExtendedTcpTable
+        /// http://msdn2.microsoft.com/en-us/library/aa366386.aspx
+        /// </summary>
+        private enum TcpTableType
+        {
+            BasicListener,
+            BasicConnections,
+            BasicAll,
+            OwnerPidListener,
+            OwnerPidConnections,
+            OwnerPidAll,
+            OwnerModuleListener,
+            OwnerModuleConnections,
+            OwnerModuleAll
+        }
+
+/* This code is now obsolete as I'm now using pointer-arithmetic to directly access the table rows instead of mapping structs on top of the 
+ * returned block of data. I'm keeping the code here for now for debugging purposes.*/
+        // http://msdn2.microsoft.com/en-us/library/aa366913.aspx
+        [StructLayout(LayoutKind.Sequential)]
+        private struct TcpRow
+        {
+            [MarshalAs(UnmanagedType.U4)]
+            internal UInt32 tcpState;
+            [MarshalAs(UnmanagedType.U4)]
+            internal UInt32 localAddr;
+            [MarshalAs(UnmanagedType.U4)]
+            internal UInt32 localPortInNetworkOrder;
+            [MarshalAs(UnmanagedType.U4)]
+            internal UInt32 remoteAddr;
+            [MarshalAs(UnmanagedType.U4)]
+            internal UInt32 remotePortInNetworkOrder;
+            [MarshalAs(UnmanagedType.U4)]
+            internal Int32 owningPid;
+        }
+        private static string TcpRowToString(TcpRow rowInput)
+        {
+            return String.Format(">{0}:{1} to {2}:{3} is {4} by 0x{5:x}",
+                (rowInput.localAddr & 0xFF) + "." + ((rowInput.localAddr & 0xFF00) >> 8) + "." + ((rowInput.localAddr & 0xFF0000) >> 16) + "." + ((rowInput.localAddr & 0xFF000000) >> 24),
+                ((rowInput.localPortInNetworkOrder & 0xFF00) >> 8) + ((rowInput.localPortInNetworkOrder & 0xFF) << 8),
+                (rowInput.remoteAddr & 0xFF) + "." + ((rowInput.remoteAddr & 0xFF00) >> 8) + "." + ((rowInput.remoteAddr & 0xFF0000) >> 16) + "." + ((rowInput.remoteAddr & 0xFF000000) >> 24),
+                ((rowInput.remotePortInNetworkOrder & 0xFF00) >> 8) + ((rowInput.remotePortInNetworkOrder & 0xFF) << 8),
+                rowInput.tcpState,
+                rowInput.owningPid);
+        }
+
+        #endregion IPHelper_PInvokes
+
+        /// <summary>
+        /// Map a local port number to the originating process ID
+        /// </summary>
+        /// <param name="iPort">The local port number</param>
+        /// <returns>The originating process ID</returns>
+        internal static int MapLocalPortToProcessId(int iPort)
+        {
+            Debug.Assert(((iPort > 0) && (iPort < 65536)), "Unexpected client port value");
+            // Stopwatch oSW = Stopwatch.StartNew();
+            int result = FindPIDForPort(iPort);
+            // FiddlerApplication.Log.LogString("Port hunt took: " + oSW.ElapsedMilliseconds); // Current version seems to take about 1ms on average, with a range up to ~35ms.
+            return result;
+        }
+      
+        /// <summary>
+        /// Calls the GetExtendedTcpTable function to map a port to a process ID.
+        /// This function is (over) optimized for performance.
+        /// </summary>
+        /// <param name="iTargetPort">Client port</param>
+        /// <param name="iAddressType">AF_INET or AF_INET6</param>
+        /// <returns>PID, if found, or 0</returns>
+        private static int FindPIDForConnection(int iTargetPort, uint iAddressType)
+        {
+            Debug.Assert(iAddressType == AF_INET6 || iAddressType == AF_INET);
+            IntPtr ptrTcpTable = IntPtr.Zero;
+            UInt32 tcpTableLength = 0;
+
+            int iOffsetToFirstPort = 12;
+            int iOffsetToPIDInRow = 12;
+            int iTableRowSize = 24; // 24 == Marshal.SizeOf(typeof(TcpRow));
+
+            // IPv6 tables are a different size, so adjust the offsets accordingly
+            if (iAddressType == AF_INET6)
+            {
+                iOffsetToFirstPort = 24;
+                iOffsetToPIDInRow = 32;
+                iTableRowSize = 56;
+            }
+
+            // Determine the size of the memory block to allocate
+            if (ERROR_INSUFFICIENT_BUFFER == GetExtendedTcpTable(ptrTcpTable, ref tcpTableLength, false, iAddressType, TcpTableType.OwnerPidListener, 0))
+            {
+                try
+                {
+                    ptrTcpTable = Marshal.AllocHGlobal((Int32)tcpTableLength);
+
+                    // Would it be faster to set the SORTED argument to true, and then iterate the table in reverse order?
+                    if (NO_ERROR == GetExtendedTcpTable(ptrTcpTable, ref tcpTableLength, false, iAddressType, TcpTableType.OwnerPidListener, 0))
+                    {
+                        // Convert port we're looking for into Network byte order
+                        int iTargetPortInNetOrder = ((iTargetPort & 0xFF) << 8) + ((iTargetPort & 0xFF00) >> 8);
+
+                        // ISSUE: This function APPEARS to work fine, but might blow up on Itanium or exotic architectures like that. As noted in the docs:
+                        // The MIB_TCPTABLE_OWNER_PID structure may contain padding for alignment between the dwNumEntries member and the first MIB_TCPROW_OWNER_PID
+                        // array entry in the table  member. Padding for alignment may also be present between the MIB_TCPROW_OWNER_PID array entries in the table member. 
+                        // Any access to a MIB_TCPROW_OWNER_PID array entry should assume padding may exist. 
+                        //
+                        // I have absolutely no idea how to detect such padding, or if .NET handles it automatically if I use PtrToStructure rather than the direct pointer 
+                        // manipulation calls this function is now using.
+                        //
+                        int tableLen = Marshal.ReadInt32(ptrTcpTable);          // Get table row count
+                        if (tableLen == 0)
+                        {
+                            Debug.Assert(false, "How is it possible that the API succeeded and there are really no network connections? Maybe pure IPv6 environment?");
+                            return 0;
+                        }
+                        IntPtr ptrRow = (IntPtr)((long)ptrTcpTable + iOffsetToFirstPort);       // Advance pointer to first Port in the table
+
+                        // Iterate each row of the table, looking to see if localPortInNetworkOrder matches. If it does, return the owningPid
+                        for (int i = 0; i < tableLen; ++i)
+                        {
+                            // Check for matching local port
+                            if (iTargetPortInNetOrder == Marshal.ReadInt32(ptrRow))
+                            {
+                                return Marshal.ReadInt32(ptrRow, iOffsetToPIDInRow);    
+                                // Note: the finally clause below will clean up memory
+                            }
+
+                            // Move to the next row
+                            ptrRow = (IntPtr)((long)ptrRow + iTableRowSize);
+                        }
+                    }
+                    else
+                    {
+                        throw new Exception(string.Format("GetExtendedTcpTable() returned error #{0}", Marshal.GetLastWin32Error().ToString()));
+                    }
+                }
+                finally
+                {
+                    // Clean up unmanaged memory block. Call succeeds even if tcpTable == 0.
+                    Marshal.FreeHGlobal(ptrTcpTable);
+                }
+            }
+            else
+            {
+                throw new Exception(string.Format("Initial call to GetExtendedTcpTable() returned error #{0}", Marshal.GetLastWin32Error().ToString()));
+            }
+            return 0;
+        }
+
+        /// <summary>
+        /// Given a local port number, uses GetExtendedTcpTable to find the originating process ID. 
+        /// First checks the IPv4 connections, then looks at IPv6 connections
+        /// </summary>
+        /// <param name="iTargetPort">Client applications' port</param>
+        /// <returns>ProcessID, or 0 if not found</returns>
+        private static int FindPIDForPort(int iTargetPort)
+        {          
+            int iPID = 0;
+            try
+            {
+                const bool bEnableIPv6 = true;
+                iPID = FindPIDForConnection(iTargetPort, AF_INET);
+                if ((iPID > 0) || !bEnableIPv6) return iPID;
+                return FindPIDForConnection(iTargetPort, AF_INET6);
+            }
+            catch (Exception eX)
+            {
+                //FiddlerApplication.Log.LogFormat("Fiddler.Network.TCPTable> Unable to call IPHelperAPI function: {0}", eX.Message);
+                Debug.Assert(false, "Unable to call IPHelperAPI function" + eX.Message);
+            }
+
+            // If we got here, we didn't find the connection; this will occur if the connection is from a remote client.
+            // FiddlerApplication.Log.LogFormat("Fiddler.Network.TCPTable.Error> Unable to find process information for port #{0} in table of length {1}", iTargetPort, tcpTableLength);
+            return 0;
+        }
+    }
+}

--- a/Windows/scratch-link/Util/FiddlerWinsock.cs
+++ b/Windows/scratch-link/Util/FiddlerWinsock.cs
@@ -1,4 +1,4 @@
-﻿// This sample is provided "AS IS" and confers no warranties.
+// This sample is provided "AS IS" and confers no warranties.
 // You are granted a non-exclusive, worldwide, royalty-free license to reproduce this code,
 // prepare derivative works, and distribute it or any derivative works that you create.
 //
@@ -118,14 +118,14 @@ namespace Fiddler
             }
 
             // Determine the size of the memory block to allocate
-            if (ERROR_INSUFFICIENT_BUFFER == GetExtendedTcpTable(ptrTcpTable, ref tcpTableLength, false, iAddressType, TcpTableType.OwnerPidListener, 0))
+            if (ERROR_INSUFFICIENT_BUFFER == GetExtendedTcpTable(ptrTcpTable, ref tcpTableLength, false, iAddressType, TcpTableType.OwnerPidAll, 0))
             {
                 try
                 {
                     ptrTcpTable = Marshal.AllocHGlobal((Int32)tcpTableLength);
 
                     // Would it be faster to set the SORTED argument to true, and then iterate the table in reverse order?
-                    if (NO_ERROR == GetExtendedTcpTable(ptrTcpTable, ref tcpTableLength, false, iAddressType, TcpTableType.OwnerPidListener, 0))
+                    if (NO_ERROR == GetExtendedTcpTable(ptrTcpTable, ref tcpTableLength, false, iAddressType, TcpTableType.OwnerPidAll, 0))
                     {
                         // Convert port we're looking for into Network byte order
                         int iTargetPortInNetOrder = ((iTargetPort & 0xFF) << 8) + ((iTargetPort & 0xFF00) >> 8);


### PR DESCRIPTION
### Proposed Changes

On Windows only (for now): if Scratch Link fails to bind its communication port, try to display the process ID and name for any process using that port.

Before:
![image](https://user-images.githubusercontent.com/7019101/84822319-55290a00-afd1-11ea-9666-1890cffc377a.png)

After:
![image](https://user-images.githubusercontent.com/7019101/84822431-7be74080-afd1-11ea-9fbf-1fa8d2a4b524.png)

Note that `FiddlerWinsock.cs` was written by another group and should be treated as an external dependency. Also, `AddressInUse.Designer.cs` and `AddressInUse.resx` are auto-generated code created by the dialog editor tool in Visual Studio.

### Reason for Changes

Under normal circumstances a particular port can only be used by one application at a time. If Scratch Link fails to bind its port, the most likely reason is that another application has already bound that port. Previously, Scratch Link would report this but figuring out which application is causing the conflict requires running commands at an administrator-level command prompt, which is at best difficult to explain and at worst impossible for users with restricted permissions.

This feature should help users figure out which application(s) are conflicting with Scratch Link without needing to use a command prompt.

Based on help desk tickets, this seems to affect Windows users much more often than macOS users. I still intend to implement this on macOS in a separate change.