### PR TITLE
Improve certificate loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.cer
 *.crt
 *.der
+*.enc
 *.key
 *.pem
 *.pfx

--- a/Certificates/convert-certificates.sh
+++ b/Certificates/convert-certificates.sh
@@ -15,7 +15,7 @@ set -e
 
 ######
 
-mkdir -p out
+mkdir -p int out
 
 # Code to split a PEM, in case a future version of the certificate goes back to PEM format:
 #if [ "`uname`" == "Darwin" ]; then
@@ -37,15 +37,16 @@ openssl pkcs12 \
 	-in scratch-device-manager.cer \
 	-name "Scratch Link & Scratch Device Manager" \
 	-passout pass:Scratch \
-	-export -out out/scratch-device-manager.pfx
+	-export -out int/scratch-device-manager.pfx
+
+openssl enc -aes-256-cbc -pass pass:Scratch -in int/scratch-device-manager.pfx -out out/scratch-device-manager.pfx.enc
 
 # Perfect on Mac wants a single PEM containing the certificate and key along with the whole CA chain
 # Using grep this way enforces newlines between files
 grep -h ^ {scratch-device-manager,intermediate,certificate-authority}.cer scratch-device-manager.key \
 	| tr -d '\r' \
-	> out/scratch-device-manager.pem
+	> int/scratch-device-manager.pem
 
-# Copy the PFX for the Windows build (the Mac Makefile "pulls" its certificates)
-cp -v out/scratch-device-manager.pfx ../Windows/scratch-link/Resources/
+openssl enc -aes-256-cbc -pass pass:Scratch -in int/scratch-device-manager.pem -out out/scratch-device-manager.pem.enc
 
 ls -l out/

--- a/Certificates/roll.sh
+++ b/Certificates/roll.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "IV=\"`hexdump -n 16 -e '4/4 "%08X"' /dev/random`\""
+echo "KEY=\"`hexdump -n 32 -e '8/4 "%08X"' /dev/random`\""

--- a/Windows/scratch-link.sln
+++ b/Windows/scratch-link.sln
@@ -9,10 +9,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		..\Certificates\convert-certificates.sh = ..\Certificates\convert-certificates.sh
 		generate-images.sh = generate-images.sh
 		msiZipWithVersion.targets = msiZipWithVersion.targets
 		..\playground.html = ..\playground.html
 		..\README.md = ..\README.md
+		..\Certificates\roll.sh = ..\Certificates\roll.sh
 		scratchVersion.targets = scratchVersion.targets
 		updateAppxManifest.targets = updateAppxManifest.targets
 	EndProjectSection

--- a/Windows/scratch-link/App.cs
+++ b/Windows/scratch-link/App.cs
@@ -2,9 +2,11 @@ using Fleck;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Net.Sockets;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Windows.Forms;
 
@@ -13,6 +15,17 @@ namespace scratch_link
     public class App : ApplicationContext
     {
         public const int SDMPort = 20110;
+
+        private static class EncodingParams
+        {
+            public static readonly byte[] Key = {
+                0xD8, 0x97, 0xEB, 0x08, 0xE0, 0xE9, 0xDE, 0x8F, 0x0B, 0x77, 0xAD, 0x42, 0x35, 0x02, 0xAF, 0xA5,
+                0x13, 0x72, 0xF8, 0xDA, 0xB0, 0xCB, 0xBE, 0x65, 0x0C, 0x1A, 0x1C, 0xBD, 0x5B, 0x10, 0x90, 0xD9
+            };
+            public static readonly byte[] IV = {
+                0xB5, 0xE4, 0x1D, 0xCC, 0x5B, 0x4D, 0x6F, 0xCD, 0x1C, 0x1E, 0x02, 0x84, 0x30, 0xB9, 0x21, 0xE6
+            };
+        }
 
         private static class SDMPath
         {
@@ -59,7 +72,7 @@ namespace scratch_link
                 sessionManager.ActiveSessionCountChanged += new EventHandler(UpdateIconText);
             }
 
-            var certificate = new X509Certificate2(scratch_link.Properties.Resources.WssCertificate, "Scratch");
+            var certificate = GetWssCertificate();
             _server = new WebSocketServer($"wss://0.0.0.0:{SDMPort}", false)
             {
                 RestartAfterListenError = true,
@@ -84,6 +97,46 @@ namespace scratch_link
             }
 
             UpdateIconText(this, null);
+        }
+
+        private byte[] DecryptBuffer(byte[] encrypted)
+        {
+            const int bufferSize = 4096;
+
+            using (MemoryStream decrypted = new MemoryStream())
+            {
+                var aes = Aes.Create();
+                aes.Mode = CipherMode.CBC;
+                aes.Padding = PaddingMode.PKCS7;
+                aes.Key = EncodingParams.Key;
+                aes.IV = EncodingParams.IV;
+
+                var decryptor = aes.CreateDecryptor();
+                using (var encryptedStream = new MemoryStream(encrypted))
+                {
+                    using (var cryptoStream = new CryptoStream(encryptedStream, decryptor, CryptoStreamMode.Read))
+                    {
+                        using (var decryptedStream = new MemoryStream())
+                        {
+                            var buffer = new byte[bufferSize];
+                            int count;
+                            while ((count = cryptoStream.Read(buffer, 0, buffer.Length)) != 0)
+                            {
+                                decryptedStream.Write(buffer, 0, count);
+                            }
+                            return decryptedStream.ToArray();
+                        }
+                    }
+                }
+            }
+        }
+
+        private X509Certificate2 GetWssCertificate()
+        {
+            var encryptedBytes = scratch_link.Properties.Resources.EncryptedWssCertificate;
+            var certificateBytes = DecryptBuffer(encryptedBytes);
+            var certificate = new X509Certificate2(certificateBytes, "Scratch");
+            return certificate;
         }
 
         private void OnAddressInUse()

--- a/Windows/scratch-link/Properties/Resources.Designer.cs
+++ b/Windows/scratch-link/Properties/Resources.Designer.cs
@@ -80,22 +80,22 @@ namespace scratch_link.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized resource of type System.Byte[].
+        /// </summary>
+        internal static byte[] EncryptedWssCertificate {
+            get {
+                object obj = ResourceManager.GetObject("EncryptedWssCertificate", resourceCulture);
+                return ((byte[])(obj));
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Icon similar to (Icon).
         /// </summary>
         internal static System.Drawing.Icon NotifyIcon {
             get {
                 object obj = ResourceManager.GetObject("NotifyIcon", resourceCulture);
                 return ((System.Drawing.Icon)(obj));
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized resource of type System.Byte[].
-        /// </summary>
-        internal static byte[] WssCertificate {
-            get {
-                object obj = ResourceManager.GetObject("WssCertificate", resourceCulture);
-                return ((byte[])(obj));
             }
         }
     }

--- a/Windows/scratch-link/Properties/Resources.resx
+++ b/Windows/scratch-link/Properties/Resources.resx
@@ -124,8 +124,8 @@
   <data name="AppIcon" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\ScratchLink.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="WssCertificate" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\scratch-device-manager.pfx;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="EncryptedWssCertificate" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\..\..\Certificates\out\scratch-device-manager.pfx.enc;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="NotifyIcon" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\NotifyIcon.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>

--- a/Windows/scratch-link/ScratchLink.csproj
+++ b/Windows/scratch-link/ScratchLink.csproj
@@ -76,15 +76,15 @@
     <Compile Include="GattHelpers.cs" />
     <Compile Include="BTSession.cs" />
     <Compile Include="JSONRPCException.cs" />
-    <Compile Include="Session.cs" />
-    <Compile Include="SessionManager.cs" />
-    <Compile Include="App.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Session.cs" />
+    <Compile Include="SessionManager.cs" />
+    <Compile Include="App.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Settings.Designer.cs">
       <AutoGen>True</AutoGen>
       <DependentUpon>Settings.settings</DependentUpon>
@@ -105,7 +105,6 @@
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
-    <None Include="Resources\scratch-device-manager.pfx" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/macOS/Makefile
+++ b/macOS/Makefile
@@ -69,9 +69,11 @@ dist/tmp.devid/app/$(APP_BUNDLE): dist/$(APP_BUNDLE)
 	codesign --sign "Developer ID Application: $(SIGN_ID)" --identifier "$(APP_ID)" --deep --entitlements Packaging/entitlements.plist "$@"
 	find "$@" -type f -perm +111 -print0 | xargs -0 codesign --verify --verbose
 
+# TODO: remove "-Xswiftc -Xfrontend -Xswiftc -validate-tbd-against-ir=none"
+# once Perfect-Crypto builds in debug without it
 $(BIN_FILE): $(SWIFT_SOURCES)
 	@echo "Build Version: $(APP_VERSION) $(VERSION_DETAIL)"
-	swift build --configuration $(CONFIG) --no-static-swift-stdlib -Xlinker -rpath -Xlinker '@executable_path/../Frameworks'
+	swift build --configuration $(CONFIG) --no-static-swift-stdlib -Xlinker -rpath -Xlinker '@executable_path/../Frameworks' -Xswiftc -Xfrontend -Xswiftc -validate-tbd-against-ir=none
 
 xcodeproj:
 	swift package generate-xcodeproj
@@ -88,7 +90,7 @@ $(APP_DEST): $(BIN_FILE) Packaging/entitlements.plist Packaging/Info.plist dist/
 	plutil -replace "CFBundleShortVersionString" -string "$(APP_VERSION)" "$@/Contents/Info.plist"
 	plutil -replace "ScratchVersionDetail" -string "$(VERSION_DETAIL)" "$@/Contents/Info.plist"
 	mkdir -p "$@/Contents/Resources"
-	cp -rv ../Certificates/out/scratch-device-manager.pem "$@/Contents/Resources/"
+	cp -rv ../Certificates/out/scratch-device-manager.pem.enc "$@/Contents/Resources/"
 	iconutil -c icns --output "$@/Contents/Resources/Scratch Link.icns" "dist/Scratch Link.iconset"
 	iconutil -c icns --output "$@/Contents/Resources/iconTemplate.icns" "dist/iconTemplate.iconset"
 

--- a/macOS/Sources/scratch-link/main.swift
+++ b/macOS/Sources/scratch-link/main.swift
@@ -1,5 +1,6 @@
 import Cocoa
 import Foundation
+import PerfectCrypto
 import PerfectHTTP
 import PerfectHTTPServer
 import PerfectWebSockets
@@ -9,6 +10,16 @@ let SDMPort: Int = 20110
 enum SDMRoute: String {
     case bluetoothLowEnergy = "/scratch/ble"
     case bluetooth = "/scratch/bt"
+}
+
+struct EncodingParams {
+    static let key: [UInt8] = [
+        0xD8, 0x97, 0xEB, 0x08, 0xE0, 0xE9, 0xDE, 0x8F, 0x0B, 0x77, 0xAD, 0x42, 0x35, 0x02, 0xAF, 0xA5,
+        0x13, 0x72, 0xF8, 0xDA, 0xB0, 0xCB, 0xBE, 0x65, 0x0C, 0x1A, 0x1C, 0xBD, 0x5B, 0x10, 0x90, 0xD9
+    ]
+    static let iv: [UInt8] = [
+        0xB5, 0xE4, 0x1D, 0xCC, 0x5B, 0x4D, 0x6F, 0xCD, 0x1C, 0x1E, 0x02, 0x84, 0x30, 0xB9, 0x21, 0xE6
+    ]
 }
 
 enum InitializationError: Error {
@@ -112,15 +123,15 @@ class ScratchLink: NSObject, NSApplicationDelegate {
         sessionManagers[SDMRoute.bluetoothLowEnergy.rawValue] = SessionManager<BLESession>()
         sessionManagers[SDMRoute.bluetooth.rawValue] = SessionManager<BTSession>()
 
-        guard let certPath = Bundle.main.path(forResource: "scratch-device-manager", ofType: "pem") else {
-            throw InitializationError.server("Failed to find certificate resource")
+        guard let certificate = getWssCertificate() else {
+            throw InitializationError.server("Failed to load certificate resource")
         }
         var routes = Routes()
         routes.add(method: .get, uri: "/scratch/*", handler: requestHandler)
         print("Starting server...")
         do {
             try HTTPServer.launch(wait: false, HTTPServer.Server(
-                tlsConfig: TLSConfiguration(certPath: certPath),
+                tlsConfig: TLSConfiguration(cert: certificate),
                 name: "device-manager.scratch.mit.edu",
                 port: SDMPort,
                 routes: routes
@@ -129,6 +140,36 @@ class ScratchLink: NSObject, NSApplicationDelegate {
             try handleLaunchError(error)
         }
         print("Server started")
+    }
+
+    func getFileBytes(path: String) -> [UInt8]? {
+        guard let data = NSData(contentsOfFile: path) else {
+            return nil
+        }
+        var bytes = [UInt8](repeating: 0, count: data.length)
+        data.getBytes(&bytes, length: data.length)
+        return bytes
+    }
+
+    func getWssCertificate() -> String? {
+        guard let encryptedCertPath = Bundle.main.path(forResource: "scratch-device-manager", ofType: "pem.enc") else {
+            // This probably means the file is missing from the bundle
+            return nil
+        }
+        guard let encryptedBytes = getFileBytes(path: encryptedCertPath) else {
+            return nil
+        }
+
+        guard let decryptedBytes = encryptedBytes
+            .decrypt(Cipher.aes_256_cbc, key: EncodingParams.key, iv: EncodingParams.iv) else {
+            // This probably means a key or IV problem
+            return nil
+        }
+
+        guard let decryptedString = String(bytes: decryptedBytes, encoding: .utf8) else {
+            return nil
+        }
+        return decryptedString
     }
 
     func does(string text: String, match regex: NSRegularExpression) -> Bool {


### PR DESCRIPTION
### Proposed Changes

Load an encrypted version of the HTTPS / WSS certificate files then decrypt them in memory using the encryption libraries already used by Scratch Link. Specifically, the certificates are now encrypted using what OpenSSL calls AES-256-CBC. Also, the Windows build now uses the certificate file under `Certificates/out/` instead of copying it into the build tree, reducing the chance that it will be accidentally checked in.

### Reason for Changes

This should reduce the chances of future certificate problems caused by automated file inspection tools.