### PR TITLE
Update certificates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ commands:
                     echo "$2" | base64 --decode > "$1"
                   }
                   echo "Importing SSL certificate"
+                  mkdir -p in
                   decodeToFile in/device-manager_scratch_mit_edu.crt "${SDM_CERT}"
                   decodeToFile in/device-manager_scratch_mit_edu.ca-bundle "${SDM_CERT_CA_BUNDLE}"
                   decodeToFile in/scratch-device-manager.key "${SDM_CERT_KEY}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,10 +53,9 @@ commands:
                     echo "$2" | base64 --decode > "$1"
                   }
                   echo "Importing SSL certificate"
-                  decodeToFile scratch-device-manager.cer "${SDM_CERT}"
-                  decodeToFile certificate-authority.cer "${SDM_CERT_CA}"
-                  decodeToFile intermediate.cer "${SDM_CERT_INT}"
-                  decodeToFile scratch-device-manager.key "${SDM_CERT_KEY}"
+                  decodeToFile in/device-manager_scratch_mit_edu.crt "${SDM_CERT}"
+                  decodeToFile in/device-manager_scratch_mit_edu.ca-bundle "${SDM_CERT_CA_BUNDLE}"
+                  decodeToFile in/scratch-device-manager.key "${SDM_CERT_KEY}"
                   echo "Importing OS-specific imformation (OSTYPE=${OSTYPE})"
                   if [[ "$OSTYPE" == "darwin"* ]]; then
                     decodeToFile code-to-learn-macos.p12 "${CSC_MACOS}"
@@ -84,8 +83,7 @@ commands:
           environment: # WiX fails with ICE errors if the environment is too big
             CSC_MACOS: ""
             SDM_CERT: ""
-            SDM_CERT_CA: ""
-            SDM_CERT_INT: ""
+            SDM_CERT_CA_BUNDLE: ""
             SDM_CERT_KEY: ""
 jobs:
   build_for_mac:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.ca-bundle
 *.cer
 *.crt
 *.der

--- a/Certificates/.gitignore
+++ b/Certificates/.gitignore
@@ -1,3 +1,4 @@
-int/
+in/
 mock/
 out/
+temp/

--- a/Certificates/convert-certificates.sh
+++ b/Certificates/convert-certificates.sh
@@ -30,20 +30,6 @@ function encryptFile () {
 
 mkdir -p temp out
 
-# Code to split a PEM, in case a future version of the certificate goes back to PEM format:
-#if [ "`uname`" == "Darwin" ]; then
-#	split -p "-----BEGIN CERTIFICATE-----" dm.pem temp/cert-
-#	mv temp/{cert-aa,scratch-device-manager.pem}
-#	mv temp/{cert-ab,int.pem}
-#	mv temp/{cert-ac,ca.pem}
-#else
-#	csplit -f temp/cert- dm.pem '/-----BEGIN CERTIFICATE-----/' '{2}'
-#	rm temp/cert-00 # empty
-#	mv temp/{cert-01,scratch-device-manager.pem}
-#	mv temp/{cert-02,int.pem}
-#	mv temp/{cert-03,ca.pem}
-#fi
-
 if [ -r "in/scratch-device-manager.key" ]; then
 	SDM_CERT_DIR="in"
 	echo "Converting from real certificates"

--- a/Certificates/mock-certificates.sh
+++ b/Certificates/mock-certificates.sh
@@ -78,21 +78,19 @@ function prep_openssl () {
 function generate_all () {
 	prep_openssl mock/ca
 	openssl genrsa -out mock/ca/private/ca.key 4096
-	openssl req -config mock/ca/openssl.conf -new -x509 -sha384 -extensions req_ca -subj "/CN=mock-ca" -key mock/ca/private/ca.key -out certificate-authority.cer
+	openssl req -config mock/ca/openssl.conf -new -x509 -sha384 -extensions req_ca -subj "/CN=mock-ca" -key mock/ca/private/ca.key -out mock/ca/certificate-authority.cer
 
 	prep_openssl mock/intermediate
 	openssl genrsa -out mock/intermediate/private/intermediate.key 2048
 	openssl req -config mock/intermediate/openssl.conf -new -sha384 -key mock/intermediate/private/intermediate.key -out mock/intermediate/certs/intermediate.csr -subj "/CN=mock-intermediate"
-	openssl ca -batch -config mock/ca/openssl.conf -md sha384 -extensions req_int -notext -keyfile mock/ca/private/ca.key -cert certificate-authority.cer -in mock/intermediate/certs/intermediate.csr -out intermediate.cer
+	openssl ca -batch -config mock/ca/openssl.conf -md sha384 -extensions req_int -notext -keyfile mock/ca/private/ca.key -cert mock/ca/certificate-authority.cer -in mock/intermediate/certs/intermediate.csr -out mock/intermediate/intermediate.cer
+
+	cat mock/intermediate/intermediate.cer mock/ca/certificate-authority.cer > mock/device-manager_scratch_mit_edu.ca-bundle
 
 	mkdir -p mock/scratch-device-manager
-	openssl req -config mock/intermediate/openssl.conf -new -keyout scratch-device-manager.key -newkey rsa:2048 -subj "/OU=Domain Control Validated/OU=PositiveSSL/CN=device-manager.scratch.mit.edu" -nodes -out mock/scratch-device-manager/scratch-device-manager.request
-	openssl ca -batch -config mock/intermediate/openssl.conf -md sha256 -extensions req_cert -keyfile mock/intermediate/private/intermediate.key -cert intermediate.cer -out scratch-device-manager.cer -infiles mock/scratch-device-manager/scratch-device-manager.request
+	openssl req -config mock/intermediate/openssl.conf -new -keyout mock/scratch-device-manager.key -newkey rsa:2048 -subj "/OU=Domain Control Validated/OU=PositiveSSL/CN=device-manager.scratch.mit.edu" -nodes -out mock/scratch-device-manager/scratch-device-manager.request
+	openssl ca -batch -config mock/intermediate/openssl.conf -md sha256 -extensions req_cert -keyfile mock/intermediate/private/intermediate.key -cert mock/intermediate/intermediate.cer -out mock/device-manager_scratch_mit_edu.crt -infiles mock/scratch-device-manager/scratch-device-manager.request
 }
 
-if [ -f scratch-device-manager.cer -o -f scratch-device-manager.key ]; then
-	echo "Refusing to overwrite existing files"
-else
-	generate_all
-	display_info
-fi
+generate_all
+display_info

--- a/README.md
+++ b/README.md
@@ -40,17 +40,20 @@ a pull request.
 Scratch Link provides Secure WebSocket (WSS) communication and uses digital certificates to do so. These certificates
 are **not** provided in this repository.
 
-To prepare certificates for Scratch Link development:
+To prepare certificates for Scratch Link development, run the following commands. These commands should be run from a
+`bash` prompt (or `zsh`, etc.), which on Windows means using something like [Cygwin](https://www.cygwin.com/) or
+[WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
 
-* Obtain the raw certificates: see `Certificates/convert-certificates.sh` for details. *Those outside the Scratch Team
-  will need to provide their own certificates for unofficial builds.*
-* `cd Certificates` and run `./convert-certificates.sh` to prepare the necessary certificate files.
-  * On Windows, this script can be run using [Cygwin](https://www.cygwin.com/) or
-    [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
+1. `cd Certificates`
+2. Run `./mock-certificates.sh` to generate self-signed certificates.
+3. Run `./convert-certificates.sh` to prepare the certificates for use by Scratch Link.
+
+If you are a member of the Scratch team and need the real certificates,
+see `Certificates/convert-certificates.sh` for details.
 
 ### macOS
 
-The macOS version of this project is in the `macOS` subdirectory. It uses Swift 4.x and the Swift Package Manager.
+The macOS version of this project is in the `macOS` subdirectory. It uses Swift 5.2 and the Swift Package Manager.
 
 Developer prerequisites on macOS, most of which are available through [Homebrew](https://brew.sh/):
 
@@ -60,7 +63,6 @@ Developer prerequisites on macOS, most of which are available through [Homebrew]
 * [pngcrush](https://pmt.sourceforge.io/pngcrush/)
 * [swiftlint](https://github.com/realm/SwiftLint) (optional)
 * Swift Version Manager [swiftenv](https://swiftenv.fuller.li/) (optional)
-  * If you have Swift 5 or above / Xcode 10.2 or above `swiftenv` might be the best way to get Swift 4.x
 
 The build is primarily controlled through `make`:
 

--- a/Windows/scratch-link.sln
+++ b/Windows/scratch-link.sln
@@ -7,16 +7,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScratchLink", "scratch-link
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{56ED428E-4406-49E4-A454-B5B8EE848E66}"
 	ProjectSection(SolutionItems) = preProject
-		.gitattributes = .gitattributes
-		.gitignore = .gitignore
-		..\Certificates\convert-certificates.sh = ..\Certificates\convert-certificates.sh
-		generate-images.sh = generate-images.sh
-		msiZipWithVersion.targets = msiZipWithVersion.targets
+		..\.editorconfig = ..\.editorconfig
+		..\.gitattributes = ..\.gitattributes
+		..\.gitignore = ..\.gitignore
+		..\.markdownlintrc = ..\.markdownlintrc
+		..\LICENSE = ..\LICENSE
 		..\playground.html = ..\playground.html
 		..\README.md = ..\README.md
-		..\Certificates\roll.sh = ..\Certificates\roll.sh
-		scratchVersion.targets = scratchVersion.targets
-		updateAppxManifest.targets = updateAppxManifest.targets
+		..\TRADEMARK = ..\TRADEMARK
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentation", "{3721552C-638C-48CC-A154-F995CEA87505}"
@@ -33,6 +31,25 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".circleci", ".circleci", "{2E316847-3325-4060-9560-ED29CF3D1156}"
 	ProjectSection(SolutionItems) = preProject
 		..\.circleci\config.yml = ..\.circleci\config.yml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Certificates", "Certificates", "{5A64E725-FF21-40FD-B327-F4E23907D4F6}"
+	ProjectSection(SolutionItems) = preProject
+		..\Certificates\.gitignore = ..\Certificates\.gitignore
+		..\Certificates\convert-certificates.sh = ..\Certificates\convert-certificates.sh
+		..\Certificates\mock-certificates.sh = ..\Certificates\mock-certificates.sh
+		..\Certificates\README.md = ..\Certificates\README.md
+		..\Certificates\roll.sh = ..\Certificates\roll.sh
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Windows", "Windows", "{9D623B8E-EB4D-44BE-AD1C-17363FEABAFF}"
+	ProjectSection(SolutionItems) = preProject
+		.gitattributes = .gitattributes
+		.gitignore = .gitignore
+		generate-images.sh = generate-images.sh
+		msiZipWithVersion.targets = msiZipWithVersion.targets
+		scratchVersion.targets = scratchVersion.targets
+		updateAppxManifest.targets = updateAppxManifest.targets
 	EndProjectSection
 EndProject
 Global
@@ -59,6 +76,8 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{3721552C-638C-48CC-A154-F995CEA87505} = {56ED428E-4406-49E4-A454-B5B8EE848E66}
 		{2E316847-3325-4060-9560-ED29CF3D1156} = {56ED428E-4406-49E4-A454-B5B8EE848E66}
+		{5A64E725-FF21-40FD-B327-F4E23907D4F6} = {56ED428E-4406-49E4-A454-B5B8EE848E66}
+		{9D623B8E-EB4D-44BE-AD1C-17363FEABAFF} = {56ED428E-4406-49E4-A454-B5B8EE848E66}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8DE7771A-9DD3-44DD-AA08-46514DA0F673}


### PR DESCRIPTION
### Resolves

Resolves #175 

### Proposed Changes

* Update `convert-certificates.sh` to handle our new certificate files
* Update `mock-certificates.sh` to generate mock certificates which look like our new certificate files
* A few "quality of life" improvements, including:
   * Better organization of non-project files in the Visual Studio Solution file
   * Real and mock certificates can now exist side-by-side, making it easier to switch between them:
      * Real certificates are expected to be placed in `Certificates/in` if present
      * Mock certificates are now generated in and read from `Certificates/mock`
   * When converting certificate files, intermediate files now go in `Certificates/temp/` instead of `Certificates/int` (which was short for "intermediate" but that might not be obvious)
* Update the `README.md` to reflect all these recent changes

### Reason for Changes

The new certificate files are bundled a bit differently, so the scripts needed to be updated. The new certificate files are the real fix for #175.
