### PR TITLE
Windows: Use TLS 1.2

### DIFF
--- a/Windows/scratch-link/App.cs
+++ b/Windows/scratch-link/App.cs
@@ -77,7 +77,10 @@ namespace scratch_link
             {
                 RestartAfterListenError = true,
                 Certificate = certificate,
-                EnabledSslProtocols = System.Security.Authentication.SslProtocols.Tls12
+                EnabledSslProtocols =
+                    System.Security.Authentication.SslProtocols.Tls |
+                    System.Security.Authentication.SslProtocols.Tls11 |
+                    System.Security.Authentication.SslProtocols.Tls12
             };
             _server.ListenerSocket.NoDelay = true;
 

--- a/Windows/scratch-link/App.cs
+++ b/Windows/scratch-link/App.cs
@@ -76,7 +76,8 @@ namespace scratch_link
             _server = new WebSocketServer($"wss://0.0.0.0:{SDMPort}", false)
             {
                 RestartAfterListenError = true,
-                Certificate = certificate
+                Certificate = certificate,
+                EnabledSslProtocols = System.Security.Authentication.SslProtocols.Tls12
             };
             _server.ListenerSocket.NoDelay = true;
 


### PR DESCRIPTION
@colbygk, I'm adding you as a reviewer in case you have thoughts about TLS versions. For example, is there any reason to also enable TLS 1.1 or even 1.0?

### Resolves

Resolves #179 

### Proposed Changes

Explicitly specify TLS 1.2 when starting the WebSocket server.

### Reason for Changes

Previously we relied on the default, which turns out to be only the TLS 1.0 protocol (verified with `nmap`). Chrome recently started blocking TLS 1.0 and TLS 1.1 as obsolete, so existing versions of Scratch Link are starting to be blocked. It seems Firefox is doing something similar.

It would be nice to also enable TLS 1.3 but our current SSL library doesn't support that. These are the options currently available; they can be combined but I'm not aware of any reason to do so:

```csharp
    //
    // Summary:
    //     Defines the possible versions of System.Security.Authentication.SslProtocols.
    [Flags]
    public enum SslProtocols
    {
        //
        // Summary:
        //     No SSL protocol is specified.
        None = 0,
        //
        // Summary:
        //     Specifies the SSL 2.0 protocol. SSL 2.0 has been superseded by the TLS protocol
        //     and is provided for backward compatibility only.
        Ssl2 = 12,
        //
        // Summary:
        //     Specifies the SSL 3.0 protocol. SSL 3.0 has been superseded by the TLS protocol
        //     and is provided for backward compatibility only.
        Ssl3 = 48,
        //
        // Summary:
        //     Specifies the TLS 1.0 security protocol. The TLS protocol is defined in IETF
        //     RFC 2246.
        Tls = 192,
        //
        // Summary:
        //     Specifies that either Secure Sockets Layer (SSL) 3.0 or Transport Layer Security
        //     (TLS) 1.0 are acceptable for secure communications
        Default = 240,
        //
        // Summary:
        //     Specifies the TLS 1.1 security protocol. The TLS protocol is defined in IETF
        //     RFC 4346.
        Tls11 = 768,
        //
        // Summary:
        //     Specifies the TLS 1.2 security protocol. The TLS protocol is defined in IETF
        //     RFC 5246.
        Tls12 = 3072
    }
```
