### PR TITLE
Implement macOS app notarization

### DIFF
--- a/macOS/Makefile
+++ b/macOS/Makefile
@@ -52,13 +52,19 @@ resolve-dependencies:
 
 zip: dist/$(ZIP_FILE)
 
-dist/$(PACKAGE_FILE): dist/tmp.devid/app.notarized/$(APP_BUNDLE)
-	pkgbuild --analyze --root dist/tmp.devid/app.notarized/ dist/tmp.devid/components.plist
+# build PKG (signed but not notarized)
+dist/tmp.devid/$(PACKAGE_FILE): dist/tmp.devid/app/$(APP_BUNDLE)
+	pkgbuild --analyze --root dist/tmp.devid/app/ dist/tmp.devid/components.plist
 	plutil -replace "BundleIsRelocatable" -bool "NO" dist/tmp.devid/components.plist
-	pkgbuild --root dist/tmp.devid/app.notarized/ --install-location /Applications/ --component-plist dist/tmp.devid/components.plist dist/tmp.devid/ScratchLink.pkg
+	pkgbuild --root dist/tmp.devid/app/ --install-location /Applications/ --component-plist dist/tmp.devid/components.plist dist/tmp.devid/ScratchLink.pkg
 	productbuild --synthesize --package dist/tmp.devid/ScratchLink.pkg dist/tmp.devid/distribution.plist
 	# TODO: add a README and/or LICENSE to dist/tmp.devid/distribution.plist
 	productbuild --sign "Developer ID Installer: $(SIGN_ID)" --component-compression auto --distribution dist/tmp.devid/distribution.plist --package-path dist/tmp.devid/ "$@"
+
+# notarize and staple final PKG
+dist/$(PACKAGE_FILE): dist/tmp.devid/$(PACKAGE_FILE)
+	cp -a "$<" "$@"
+	Packaging/notarize.sh "${APP_ID}" "$<" "$@" dist/tmp.devid
 
 dist/tmp.devid/app/$(APP_BUNDLE): dist/$(APP_BUNDLE)
 	rm -rf dist/tmp.devid/app
@@ -68,32 +74,6 @@ dist/tmp.devid/app/$(APP_BUNDLE): dist/$(APP_BUNDLE)
 	test -r "$@/Contents/Frameworks/libswiftCore.dylib" # verify swift-stdlib-tool did its job
 	codesign --sign "Developer ID Application: $(SIGN_ID)" --identifier "$(APP_ID)" --deep --entitlements Packaging/entitlements.plist --options runtime "$@"
 	find "$@" -type f -perm +111 -print0 | xargs -0 codesign --verify --verbose
-
-dist/tmp.devid/$(APP_BUNDLE).zip: dist/tmp.devid/app/$(APP_BUNDLE)
-	ditto -c -k --keepParent "$<" "$@"
-
-dist/tmp.devid/$(APP_BUNDLE).upload.plist: dist/tmp.devid/$(APP_BUNDLE).zip
-	[ "$(AC_USERNAME)" != "" ] || { echo "Cannot notarize unless AC_USERNAME is set" && false; }
-	@echo "Uploading app for notarization..."
-	xcrun altool --notarize-app --primary-bundle-id "$(APP_ID)" -u "$(AC_USERNAME)" -p "@keychain:Application Loader: $(AC_USERNAME)" -f "$<" --output-format xml > "$@"
-	sleep 10s # status info might not be ready immediately after upload
-
-# patterned after https://nativeconnect.app/blog/mac-app-notarization-from-the-command-line/
-dist/tmp.devid/app.notarized/$(APP_BUNDLE): dist/tmp.devid/$(APP_BUNDLE).upload.plist dist/tmp.devid/app/$(APP_BUNDLE)
-	[ "$(AC_USERNAME)" != "" ] || { echo "Cannot notarize unless AC_USERNAME is set" && false; }
-	REQUEST_UUID=`/usr/libexec/PlistBuddy -c "Print :notarization-upload:RequestUUID" "$<"` && \
-	echo "Waiting for notarization task with UUID=$${REQUEST_UUID}. This can take a while..." && \
-	time while true; do \
-		xcrun altool --notarization-info "$${REQUEST_UUID}" -u "$(AC_USERNAME)" -p "@keychain:Application Loader: $(AC_USERNAME)" --output-format xml > dist/tmp.devid/$(APP_BUNDLE).progress.plist && \
-		if [ "`/usr/libexec/PlistBuddy -c "Print :notarization-info:Status" dist/tmp.devid/$(APP_BUNDLE).progress.plist`" != "in progress" ]; then \
-			break; \
-		fi; \
-		sleep 60s; \
-	done
-	[ "`/usr/libexec/PlistBuddy -c "Print :notarization-info:Status" dist/tmp.devid/$(APP_BUNDLE).progress.plist`" == "success" ]
-	mkdir -p dist/tmp.devid/app.notarized
-	cp -aR dist/tmp.devid/app/$(APP_BUNDLE) "$@"
-	xcrun stapler staple "$@"
 
 # TODO: remove "-Xswiftc -Xfrontend -Xswiftc -validate-tbd-against-ir=none"
 # once Perfect-Crypto builds in debug without it

--- a/macOS/Makefile
+++ b/macOS/Makefile
@@ -39,9 +39,9 @@ dist/tmp.mas/$(APP_BUNDLE): dist/$(APP_BUNDLE)
 	rm -rf dist/tmp.mas/
 	mkdir -p dist/tmp.mas/
 	cp -aR "$<" "$@"
-	xcrun swift-stdlib-tool --copy --sign "3rd Party Mac Developer Application: $(SIGN_ID)" --platform macosx --scan-folder "$@/Contents/MacOS" --destination "$@/Contents/Frameworks"
+	xcrun swift-stdlib-tool --copy --sign "3rd Party Mac Developer Application: $(SIGN_ID)" --Xcodesign --options --Xcodesign runtime --platform macosx --scan-folder "$@/Contents/MacOS" --destination "$@/Contents/Frameworks"
 	test -r "$@/Contents/Frameworks/libswiftCore.dylib" # verify swift-stdlib-tool did its job
-	codesign --sign "3rd Party Mac Developer Application: $(SIGN_ID)" --identifier "$(APP_ID)" --deep --entitlements Packaging/entitlements.plist "$@"
+	codesign --sign "3rd Party Mac Developer Application: $(SIGN_ID)" --identifier "$(APP_ID)" --deep --entitlements Packaging/entitlements.plist --options runtime "$@"
 	find "$@" -type f -perm +111 -print0 | xargs -0 codesign --verify --verbose
 
 # For "Developer ID" distribution outside the Mac App Store
@@ -64,9 +64,9 @@ dist/tmp.devid/app/$(APP_BUNDLE): dist/$(APP_BUNDLE)
 	rm -rf dist/tmp.devid/app
 	mkdir -p dist/tmp.devid/app
 	cp -aR "$<" "$@"
-	xcrun swift-stdlib-tool --copy --sign "Developer ID Application: $(SIGN_ID)" --platform macosx --scan-folder "$@/Contents/MacOS" --destination "$@/Contents/Frameworks"
+	xcrun swift-stdlib-tool --copy --sign "Developer ID Application: $(SIGN_ID)" --Xcodesign --options --Xcodesign runtime --platform macosx --scan-folder "$@/Contents/MacOS" --destination "$@/Contents/Frameworks"
 	test -r "$@/Contents/Frameworks/libswiftCore.dylib" # verify swift-stdlib-tool did its job
-	codesign --sign "Developer ID Application: $(SIGN_ID)" --identifier "$(APP_ID)" --deep --entitlements Packaging/entitlements.plist "$@"
+	codesign --sign "Developer ID Application: $(SIGN_ID)" --identifier "$(APP_ID)" --deep --entitlements Packaging/entitlements.plist --options runtime "$@"
 	find "$@" -type f -perm +111 -print0 | xargs -0 codesign --verify --verbose
 
 # TODO: remove "-Xswiftc -Xfrontend -Xswiftc -validate-tbd-against-ir=none"

--- a/macOS/Makefile
+++ b/macOS/Makefile
@@ -10,8 +10,8 @@ BIN_PATH=$(shell swift build --configuration $(CONFIG) --show-bin-path)
 
 BIN_FILE=$(BIN_PATH)/scratch-link
 APP_DEST=dist/$(APP_BUNDLE)
-PACKAGE_FILE="scratch-link-$(APP_VERSION).pkg"
-ZIP_FILE="scratch-link-$(APP_VERSION).zip"
+PACKAGE_FILE=scratch-link-$(APP_VERSION).pkg
+ZIP_FILE=scratch-link-$(APP_VERSION).zip
 SWIFT_SOURCES=$(wildcard Sources/scratch-link/*.swift)
 
 .PHONY: all bin clean dist dist-mas dist-devid distclean lint resolve-dependencies uninstall xcodeproj zip
@@ -52,10 +52,10 @@ resolve-dependencies:
 
 zip: dist/$(ZIP_FILE)
 
-dist/$(PACKAGE_FILE): dist/tmp.devid/app/$(APP_BUNDLE)
-	pkgbuild --analyze --root dist/tmp.devid/app/ dist/tmp.devid/components.plist
+dist/$(PACKAGE_FILE): dist/tmp.devid/app.notarized/$(APP_BUNDLE)
+	pkgbuild --analyze --root dist/tmp.devid/app.notarized/ dist/tmp.devid/components.plist
 	plutil -replace "BundleIsRelocatable" -bool "NO" dist/tmp.devid/components.plist
-	pkgbuild --root dist/tmp.devid/app/ --install-location /Applications/ --component-plist dist/tmp.devid/components.plist dist/tmp.devid/ScratchLink.pkg
+	pkgbuild --root dist/tmp.devid/app.notarized/ --install-location /Applications/ --component-plist dist/tmp.devid/components.plist dist/tmp.devid/ScratchLink.pkg
 	productbuild --synthesize --package dist/tmp.devid/ScratchLink.pkg dist/tmp.devid/distribution.plist
 	# TODO: add a README and/or LICENSE to dist/tmp.devid/distribution.plist
 	productbuild --sign "Developer ID Installer: $(SIGN_ID)" --component-compression auto --distribution dist/tmp.devid/distribution.plist --package-path dist/tmp.devid/ "$@"
@@ -68,6 +68,32 @@ dist/tmp.devid/app/$(APP_BUNDLE): dist/$(APP_BUNDLE)
 	test -r "$@/Contents/Frameworks/libswiftCore.dylib" # verify swift-stdlib-tool did its job
 	codesign --sign "Developer ID Application: $(SIGN_ID)" --identifier "$(APP_ID)" --deep --entitlements Packaging/entitlements.plist --options runtime "$@"
 	find "$@" -type f -perm +111 -print0 | xargs -0 codesign --verify --verbose
+
+dist/tmp.devid/$(APP_BUNDLE).zip: dist/tmp.devid/app/$(APP_BUNDLE)
+	ditto -c -k --keepParent "$<" "$@"
+
+dist/tmp.devid/$(APP_BUNDLE).upload.plist: dist/tmp.devid/$(APP_BUNDLE).zip
+	[ "$(AC_USERNAME)" != "" ] || { echo "Cannot notarize unless AC_USERNAME is set" && false; }
+	@echo "Uploading app for notarization..."
+	xcrun altool --notarize-app --primary-bundle-id "$(APP_ID)" -u "$(AC_USERNAME)" -p "@keychain:Application Loader: $(AC_USERNAME)" -f "$<" --output-format xml > "$@"
+	sleep 10s # status info might not be ready immediately after upload
+
+# patterned after https://nativeconnect.app/blog/mac-app-notarization-from-the-command-line/
+dist/tmp.devid/app.notarized/$(APP_BUNDLE): dist/tmp.devid/$(APP_BUNDLE).upload.plist dist/tmp.devid/app/$(APP_BUNDLE)
+	[ "$(AC_USERNAME)" != "" ] || { echo "Cannot notarize unless AC_USERNAME is set" && false; }
+	REQUEST_UUID=`/usr/libexec/PlistBuddy -c "Print :notarization-upload:RequestUUID" "$<"` && \
+	echo "Waiting for notarization task with UUID=$${REQUEST_UUID}. This can take a while..." && \
+	time while true; do \
+		xcrun altool --notarization-info "$${REQUEST_UUID}" -u "$(AC_USERNAME)" -p "@keychain:Application Loader: $(AC_USERNAME)" --output-format xml > dist/tmp.devid/$(APP_BUNDLE).progress.plist && \
+		if [ "`/usr/libexec/PlistBuddy -c "Print :notarization-info:Status" dist/tmp.devid/$(APP_BUNDLE).progress.plist`" != "in progress" ]; then \
+			break; \
+		fi; \
+		sleep 60s; \
+	done
+	[ "`/usr/libexec/PlistBuddy -c "Print :notarization-info:Status" dist/tmp.devid/$(APP_BUNDLE).progress.plist`" == "success" ]
+	mkdir -p dist/tmp.devid/app.notarized
+	cp -aR dist/tmp.devid/app/$(APP_BUNDLE) "$@"
+	xcrun stapler staple "$@"
 
 # TODO: remove "-Xswiftc -Xfrontend -Xswiftc -validate-tbd-against-ir=none"
 # once Perfect-Crypto builds in debug without it

--- a/macOS/Packaging/notarize.sh
+++ b/macOS/Packaging/notarize.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -e
+
+function show_usage () {
+	echo "OVERVIEW: Notarize a file then staple the results"
+	echo ""
+	echo "USAGE: $0 bundleID sourceToNotarize destinationToStaple tempDirectory"
+	echo ""
+	echo "ALL parameters are required:"
+	echo "  bundleID: the 'primary bundle ID' for the upload (see altool docs)"
+	echo "  sourceToNotarize: a zipped app bundle, a PKG, a DMG, etc., which will be uploaded to Apple's servers."
+	echo "  destinationToStaple: an app bundle directory, a PKG, a DMG, etc., which will be stapled after notarization."
+	echo "  tempDirectory: a directory in which to place temporary files, which could help with troubleshooting."
+	echo ""
+	echo "The environment variable AC_USERNAME must be set to an Apple ID which will be used for uploading to Apple."
+	echo "Your keychain must include a corresponding item labeled something like 'Application Loader: \$AC_USERNAME'"
+	false
+}
+
+# patterned after https://nativeconnect.app/blog/mac-app-notarization-from-the-command-line/
+function do_notarize () {
+	BUNDLE_ID="$1"
+	SRC="$2"
+	DST="$3"
+	TMP_DIR="$4"
+
+	PLIST_UPLOAD="${TMP_DIR}/notarize-upload.plist"
+	PLIST_STATUS="${TMP_DIR}/notarize-status.plist"
+	AC_PASSWORD="@keychain:Application Loader: ${AC_USERNAME}"
+
+	echo "Uploading ${SRC} for notarization..."
+	time xcrun altool --notarize-app --primary-bundle-id "${BUNDLE_ID}" -u "${AC_USERNAME}" -p "${AC_PASSWORD}" -f "${SRC}" --output-format xml > "${PLIST_UPLOAD}"
+	REQUEST_UUID=`/usr/libexec/PlistBuddy -c "Print :notarization-upload:RequestUUID" "${PLIST_UPLOAD}"`
+	echo "Waiting for notarization task with UUID=${REQUEST_UUID}. This can take a while..."
+	time while sleep 30s; do
+		xcrun altool --notarization-info "${REQUEST_UUID}" -u "${AC_USERNAME}" -p "${AC_PASSWORD}" --output-format xml > "${PLIST_STATUS}"
+		NOTARIZE_STATUS="`/usr/libexec/PlistBuddy -c "Print :notarization-info:Status" "${PLIST_STATUS}"`"
+		echo "Notarization ${REQUEST_UUID} status is: ${NOTARIZE_STATUS}"
+		if [ "${NOTARIZE_STATUS}" != "in progress" ]; then
+			break
+		fi
+	done
+	if [ "${NOTARIZE_STATUS}" != "success" ]; then
+		return 1
+	fi
+	echo "Stapling ${DST}"
+	xcrun stapler staple "${DST}"
+}
+
+if [ "$#" -lt 4 ]; then
+	show_usage
+elif [ "$AC_USERNAME" == "" ]; then
+	echo "Cannot notarize unless AC_USERNAME is set"
+	false
+else
+	do_notarize "$@"
+fi


### PR DESCRIPTION
### Resolves

Resolves #178 

### Proposed Changes

1. Enable the "hardened runtime" -- this is prerequisite for notarization
   * This simply means passing `--options runtime` to the existing `codesign` calls, and `--Xcodesign --options --Xcodesign runtime` to existing `swift-stdlib-tool` calls.
2. Add steps in the Makefile to notarize the application. The steps involved are, roughly:
   1. Build the installer PKG as we did before (but store it in a temp directory for now)
   2. Upload that PKG to Apple's notarization service using `altool`, AKA Application Loader
   3. Wait until Apple's servers finish notarization. This typically takes 1-3 minutes but sometimes takes more than 10 minutes.
   4. Use `stapler` to "staple" the notarization results to a new copy of the PKG. This allows the application to be verified when the user might not have an active Internet connection.

The file `macOS/Packaging/notarize.sh` takes care of running `altool`, waiting for results, and stapling. It's not quite a general utility script right now, but it's close enough for the purposes of the scratch-link build process.

My approach is largely based on this article: https://nativeconnect.app/blog/mac-app-notarization-from-the-command-line/

### Reason for Changes

In macOS Catalina and above, software that doesn't come from the Mac App Store must be notarized. Otherwise, macOS prevents the user from running the software.
