### PR TITLE
Fix builds on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ commands:
 jobs:
   build_for_mac:
     macos:
-      xcode: "11.3.1"
+      xcode: "11.7.0"
     steps:
       - checkout
       - prepare_certificates

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
                   rm Certificates/macos-certs-scratch-foundation.p12
       - restore_cache:
           name: Restore Homebrew cache
-          key: homebrew-cache-v2
+          key: homebrew-cache-v3
       - run:
           name: Install Homebrew packages
           command: brew install pngcrush
@@ -121,8 +121,8 @@ jobs:
           name: Save Homebrew cache
           paths:
             - ~/Library/Caches/Homebrew
-            - /usr/local/Homebrew
-          key: homebrew-cache-v2 # bump this version (and the one above) if you change the list of paths
+            - /Library/Caches/Homebrew
+          key: homebrew-cache-v3 # bump this version (and the one above) if you change the list of paths
       - restore_cache:
           name: Restore Swift dependency cache
           key: spm-cache-v2-{{ checksum "macOS/Package.resolved" }}

--- a/Windows/ScratchLinkSetup/ScratchLinkSetup.wixproj
+++ b/Windows/ScratchLinkSetup/ScratchLinkSetup.wixproj
@@ -23,6 +23,9 @@
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <LinkerAdditionalOptions>-ext WixUIExtension -ext WixUtilExtension</LinkerAdditionalOptions>
   </PropertyGroup>
+  <PropertyGroup Label="Work around LGHT0217 errors on CircleCI" Condition="'$(CI)' != ''">
+    <SuppressValidation>true</SuppressValidation>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="Product.wxs" />
   </ItemGroup>


### PR DESCRIPTION
### Proposed Changes

CircleCI changes for the macOS build:

* Upgrade to use Xcode 11.7.0
* Don't cache `/usr/local/Homebrew` (but keep caching `~/Libraries/Caches/Homebrew`)

CircleCI changes for the Windows build:

* Disable ICE checking for Light / WiX on CI (but keep them on local builds)

### Reason for Changes

For the macOS build:

* CircleCI no longer supports Xcode 11.3.1, so we had to upgrade. Xcode 11.7.0 is the newest version for which I'm confident our code will still build correctly.
* Restoring `/usr/local/Homebrew` from cache no longer works on the Xcode 11.7.0 image. I spent a small amount of time troubleshooting and didn't immediately find a solution, so instead I decided to disable that part of the cache for now.

For the Windows build:

* The ICE checking in Light / WiX isn't strictly necessary: it's more of a self-check to ensure that nothing is wrong with the build system itself. Unfortunately it doesn't seem to be reliable on CI, and/or it's affected negatively by some of the (large) environment variables that we need for our current build setup, so I've disabled it as recommended by some users here: https://stackoverflow.com/questions/1064580/wix-3-0-throws-error-217-while-being-executed-by-continuous-integration